### PR TITLE
feat: extract function start candidates from .pdata

### DIFF
--- a/smda/intel/FunctionCandidateManager.py
+++ b/smda/intel/FunctionCandidateManager.py
@@ -644,10 +644,9 @@ class FunctionCandidateManager:
                     # .pdata entries are 12 bytes long (3 DWORDs)
                     for offset in range(rva_start, rva_end - 11, 12):
                         packed_dword = self.disassembly.binary_info.binary[offset : offset + 4]
-                        rva_function_candidate = None
-                        if len(packed_dword) == 4:
-                            rva_function_candidate = struct.unpack("I", packed_dword)[0]
-                        # if we hit a zero entry, we assume we reached the end of the table
-                        if not rva_function_candidate:
+                        if len(packed_dword) < 4:
+                            break
+                        rva_function_candidate = struct.unpack("I", packed_dword)[0]
+                        if rva_function_candidate == 0:
                             break
                         self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)

--- a/smda/intel/FunctionCandidateManager.py
+++ b/smda/intel/FunctionCandidateManager.py
@@ -644,10 +644,10 @@ class FunctionCandidateManager:
                     # .pdata entries are 12 bytes long (3 DWORDs)
                     for offset in range(rva_start, rva_end, 12):
                         packed_dword = self.disassembly.binary_info.binary[offset : offset + 4]
-                        rva_function_candidate = None
-                        if len(packed_dword) == 4:
-                            rva_function_candidate = struct.unpack("I", packed_dword)[0]
-                            self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)
-                        # if we hit a zero entry, we assume we reached the end of the table
-                        if not rva_function_candidate:
+                        if len(packed_dword) < 4:
                             break
+                        rva_function_candidate = struct.unpack("I", packed_dword)[0]
+                        if not rva_function_candidate:
+                            # if we hit a zero entry, we assume we reached the end of the table
+                            break
+                        self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)

--- a/smda/intel/FunctionCandidateManager.py
+++ b/smda/intel/FunctionCandidateManager.py
@@ -648,5 +648,5 @@ class FunctionCandidateManager:
                             break
                         rva_function_candidate = struct.unpack("I", packed_dword)[0]
                         if rva_function_candidate == 0:
-                            continue
+                            break
                         self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)

--- a/smda/intel/FunctionCandidateManager.py
+++ b/smda/intel/FunctionCandidateManager.py
@@ -644,10 +644,9 @@ class FunctionCandidateManager:
                     # .pdata entries are 12 bytes long (3 DWORDs)
                     for offset in range(rva_start, rva_end - 11, 12):
                         packed_dword = self.disassembly.binary_info.binary[offset : offset + 4]
-                        rva_function_candidate = None
-                        if len(packed_dword) == 4:
-                            rva_function_candidate = struct.unpack("I", packed_dword)[0]
-                        # if we hit a zero entry, we assume we reached the end of the table
-                        if not rva_function_candidate:
+                        if len(packed_dword) < 4:
                             break
+                        rva_function_candidate = struct.unpack("I", packed_dword)[0]
+                        if rva_function_candidate == 0:
+                            continue
                         self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)

--- a/smda/intel/FunctionCandidateManager.py
+++ b/smda/intel/FunctionCandidateManager.py
@@ -635,18 +635,19 @@ class FunctionCandidateManager:
 
     def locateExceptionHandlerCandidates(self):
         # 64bit only - if we have a .pdata section describing exception handlers, we extract entries of guaranteed function starts from it.
-        # TODO 2020-10-29 continue here and extract function start candidates
         if self.disassembly.binary_info.bitness == 64:
             for section_info in self.disassembly.binary_info.getSections():
                 section_name, section_va_start, section_va_end = section_info
                 if section_name == ".pdata":
                     rva_start = section_va_start - self.disassembly.binary_info.base_addr
                     rva_end = section_va_end - self.disassembly.binary_info.base_addr
-                    for offset in range(rva_start, rva_end + 1, 12):
+                    # .pdata entries are 12 bytes long (3 DWORDs)
+                    for offset in range(rva_start, rva_end, 12):
                         packed_dword = self.disassembly.binary_info.binary[offset : offset + 4]
                         rva_function_candidate = None
                         if len(packed_dword) == 4:
                             rva_function_candidate = struct.unpack("I", packed_dword)[0]
                             self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)
+                        # if we hit a zero entry, we assume we reached the end of the table
                         if not rva_function_candidate:
                             break

--- a/smda/intel/FunctionCandidateManager.py
+++ b/smda/intel/FunctionCandidateManager.py
@@ -642,12 +642,12 @@ class FunctionCandidateManager:
                     rva_start = section_va_start - self.disassembly.binary_info.base_addr
                     rva_end = section_va_end - self.disassembly.binary_info.base_addr
                     # .pdata entries are 12 bytes long (3 DWORDs)
-                    for offset in range(rva_start, rva_end, 12):
+                    for offset in range(rva_start, rva_end - 11, 12):
                         packed_dword = self.disassembly.binary_info.binary[offset : offset + 4]
-                        if len(packed_dword) < 4:
-                            break
-                        rva_function_candidate = struct.unpack("I", packed_dword)[0]
+                        rva_function_candidate = None
+                        if len(packed_dword) == 4:
+                            rva_function_candidate = struct.unpack("I", packed_dword)[0]
+                        # if we hit a zero entry, we assume we reached the end of the table
                         if not rva_function_candidate:
-                            # if we hit a zero entry, we assume we reached the end of the table
                             break
                         self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -1,0 +1,109 @@
+import struct
+import unittest
+
+from smda.DisassemblyResult import DisassemblyResult
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager
+from smda.SmdaConfig import SmdaConfig
+
+BASE_ADDR = 0x140000000
+BINARY_SIZE = 0x4000
+PDATA_OFFSET = 0x1000
+
+
+class MockBinaryInfo:
+    def __init__(self, bitness, base_addr, binary, pdata_size=0):
+        self.bitness = bitness
+        self.base_addr = base_addr
+        self.binary = binary
+        self.code_areas = []
+        self.pdata_size = pdata_size
+
+    def getSections(self):
+        # yields name, start, end
+        if self.pdata_size > 0:
+            # .pdata at 0x1000
+            yield ".pdata", self.base_addr + PDATA_OFFSET, self.base_addr + PDATA_OFFSET + self.pdata_size
+
+
+class PdataExtractionTestSuite(unittest.TestCase):
+    def test_pdata_candidates(self):
+        config = SmdaConfig()
+        fcm = FunctionCandidateManager(config)
+
+        # Entry format: Start RVA, End RVA, Unwind RVA
+        entries = [(0x2000, 0x2040, 0x3000), (0x2050, 0x2090, 0x3010), (0x2100, 0x2150, 0x3020)]
+
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
+
+        # Fill binary with zeros
+        binary_size = BINARY_SIZE
+        binary = bytearray(binary_size)
+
+        # Place pdata at 0x1000
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
+
+        # Initialize Mock Disassembly and BinaryInfo
+        disasm = DisassemblyResult()
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
+
+        fcm.init(disasm)
+
+        candidates = fcm.candidates
+
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertIn(BASE_ADDR + 0x2050, candidates)
+        self.assertIn(BASE_ADDR + 0x2100, candidates)
+        self.assertEqual(len(candidates), 3)
+
+    def test_pdata_with_zero_entry(self):
+        config = SmdaConfig()
+        fcm = FunctionCandidateManager(config)
+
+        entries = [
+            (0x2000, 0x2040, 0x3000),
+            (0, 0, 0),  # Zero entry
+            (0x2100, 0x2150, 0x3020),
+        ]
+
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
+
+        binary = bytearray(BINARY_SIZE)
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
+
+        disasm = DisassemblyResult()
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
+
+        fcm.init(disasm)
+
+        candidates = fcm.candidates
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertNotIn(BASE_ADDR + 0x2100, candidates)
+        self.assertNotIn(BASE_ADDR, candidates)
+        self.assertEqual(len(candidates), 1)
+
+    def test_pdata_misaligned_size(self):
+        config = SmdaConfig()
+        fcm = FunctionCandidateManager(config)
+
+        entries = [(0x2000, 0x2040, 0x3000)]
+
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
+
+        # Add some extra bytes to make it misaligned (not multiple of 12)
+        pdata_bytes += b"\x90\x90"
+
+        binary = bytearray(BINARY_SIZE)
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
+
+        disasm = DisassemblyResult()
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
+
+        fcm.init(disasm)
+
+        candidates = fcm.candidates
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertEqual(len(candidates), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -49,6 +49,7 @@ class PdataExtractionTestSuite(unittest.TestCase):
         self.assertIn(0x140000000 + 0x2000, candidates)
         self.assertIn(0x140000000 + 0x2050, candidates)
         self.assertIn(0x140000000 + 0x2100, candidates)
+        self.assertEqual(len(candidates), 3)
 
     def test_pdata_with_zero_entry(self):
         config = SmdaConfig()

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -29,9 +29,7 @@ class PdataExtractionTestSuite(unittest.TestCase):
         # Entry format: Start RVA, End RVA, Unwind RVA
         entries = [(0x2000, 0x2040, 0x3000), (0x2050, 0x2090, 0x3010), (0x2100, 0x2150, 0x3020)]
 
-        pdata_bytes = b""
-        for start, end, unwind in entries:
-            pdata_bytes += struct.pack("III", start, end, unwind)
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
         # Fill binary with zeros
         binary_size = 0x4000
@@ -62,9 +60,7 @@ class PdataExtractionTestSuite(unittest.TestCase):
             (0x2100, 0x2150, 0x3020),
         ]
 
-        pdata_bytes = b""
-        for start, end, unwind in entries:
-            pdata_bytes += struct.pack("III", start, end, unwind)
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
         binary = bytearray(0x4000)
         binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
@@ -86,9 +82,7 @@ class PdataExtractionTestSuite(unittest.TestCase):
 
         entries = [(0x2000, 0x2040, 0x3000)]
 
-        pdata_bytes = b""
-        for start, end, unwind in entries:
-            pdata_bytes += struct.pack("III", start, end, unwind)
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
         # Add some extra bytes to make it misaligned (not multiple of 12)
         pdata_bytes += b"\x90\x90"

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -7,16 +7,18 @@ from smda.SmdaConfig import SmdaConfig
 
 
 class MockBinaryInfo:
-    def __init__(self, bitness, base_addr, binary):
+    def __init__(self, bitness, base_addr, binary, pdata_size=0):
         self.bitness = bitness
         self.base_addr = base_addr
         self.binary = binary
         self.code_areas = []
+        self.pdata_size = pdata_size
 
     def getSections(self):
         # yields name, start, end
-        # .pdata at 0x1000, size 36 (3 entries)
-        yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + 36
+        if self.pdata_size > 0:
+            # .pdata at 0x1000
+            yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + self.pdata_size
 
 
 class PdataExtractionTestSuite(unittest.TestCase):

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -1,9 +1,10 @@
-
-import unittest
 import struct
-from smda.intel.FunctionCandidateManager import FunctionCandidateManager
+import unittest
+
 from smda.DisassemblyResult import DisassemblyResult
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
+
 
 class MockBinaryInfo:
     def __init__(self, bitness, base_addr, binary):
@@ -17,17 +18,14 @@ class MockBinaryInfo:
         # .pdata at 0x1000, size 36 (3 entries)
         yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + 36
 
+
 class PdataExtractionTestSuite(unittest.TestCase):
     def test_pdata_candidates(self):
         config = SmdaConfig()
         fcm = FunctionCandidateManager(config)
 
         # Entry format: Start RVA, End RVA, Unwind RVA
-        entries = [
-            (0x2000, 0x2040, 0x3000),
-            (0x2050, 0x2090, 0x3010),
-            (0x2100, 0x2150, 0x3020)
-        ]
+        entries = [(0x2000, 0x2040, 0x3000), (0x2050, 0x2090, 0x3010), (0x2100, 0x2150, 0x3020)]
 
         pdata_bytes = b""
         for start, end, unwind in entries:
@@ -63,5 +61,6 @@ class PdataExtractionTestSuite(unittest.TestCase):
         self.assertIn(0x140000000 + 0x2050, candidates)
         self.assertIn(0x140000000 + 0x2100, candidates)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -7,7 +7,7 @@ from smda.SmdaConfig import SmdaConfig
 
 
 class MockBinaryInfo:
-    def __init__(self, bitness, base_addr, binary, pdata_size=0):
+    def __init__(self, bitness, base_addr, binary, pdata_size=36):
         self.bitness = bitness
         self.base_addr = base_addr
         self.binary = binary
@@ -16,9 +16,8 @@ class MockBinaryInfo:
 
     def getSections(self):
         # yields name, start, end
-        if self.pdata_size > 0:
-            # .pdata at 0x1000
-            yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + self.pdata_size
+        # .pdata at 0x1000
+        yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + self.pdata_size
 
 
 class PdataExtractionTestSuite(unittest.TestCase):
@@ -44,17 +43,6 @@ class PdataExtractionTestSuite(unittest.TestCase):
         disasm = DisassemblyResult()
         disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary))
 
-        # Mock code_areas in binary info so passesCodeFilter works
-        # If code_areas is empty, it returns True (see FunctionCandidateManager.py)
-
-        # We need to mock LanguageAnalyzer to avoid it running on empty/random binary and potentially crashing or taking time
-        # But FunctionCandidateManager instantiates it inside init().
-        # We can mock it by assigning to fcm.lang_analyzer *after* init? No init calls identify().
-        # We can subclass FunctionCandidateManager and override init, or just mock disassembly.binary_info.binary to be safe for LanguageAnalyzer.
-        # LanguageAnalyzer checks bytes.
-
-        # Let's try running it. If LanguageAnalyzer crashes, we will see.
-
         fcm.init(disasm)
 
         candidates = fcm.candidates
@@ -62,6 +50,58 @@ class PdataExtractionTestSuite(unittest.TestCase):
         self.assertIn(0x140000000 + 0x2000, candidates)
         self.assertIn(0x140000000 + 0x2050, candidates)
         self.assertIn(0x140000000 + 0x2100, candidates)
+
+    def test_pdata_with_zero_entry(self):
+        config = SmdaConfig()
+        fcm = FunctionCandidateManager(config)
+
+        entries = [
+            (0x2000, 0x2040, 0x3000),
+            (0, 0, 0),  # Zero entry
+            (0x2100, 0x2150, 0x3020),
+        ]
+
+        pdata_bytes = b""
+        for start, end, unwind in entries:
+            pdata_bytes += struct.pack("III", start, end, unwind)
+
+        binary = bytearray(0x4000)
+        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+
+        disasm = DisassemblyResult()
+        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
+
+        fcm.init(disasm)
+
+        candidates = fcm.candidates
+        self.assertIn(0x140000000 + 0x2000, candidates)
+        self.assertNotIn(0x140000000 + 0x2100, candidates)
+        self.assertEqual(len(candidates), 1)
+
+    def test_pdata_misaligned_size(self):
+        config = SmdaConfig()
+        fcm = FunctionCandidateManager(config)
+
+        entries = [(0x2000, 0x2040, 0x3000)]
+
+        pdata_bytes = b""
+        for start, end, unwind in entries:
+            pdata_bytes += struct.pack("III", start, end, unwind)
+
+        # Add some extra bytes to make it misaligned (not multiple of 12)
+        pdata_bytes += b"\x90\x90"
+
+        binary = bytearray(0x4000)
+        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+
+        disasm = DisassemblyResult()
+        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
+
+        fcm.init(disasm)
+
+        candidates = fcm.candidates
+        self.assertIn(0x140000000 + 0x2000, candidates)
+        self.assertEqual(len(candidates), 1)
 
 
 if __name__ == "__main__":

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -5,6 +5,10 @@ from smda.DisassemblyResult import DisassemblyResult
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
 
+BASE_ADDR = 0x140000000
+BINARY_SIZE = 0x4000
+PDATA_OFFSET = 0x1000
+
 
 class MockBinaryInfo:
     def __init__(self, bitness, base_addr, binary, pdata_size=0):
@@ -18,7 +22,7 @@ class MockBinaryInfo:
         # yields name, start, end
         if self.pdata_size > 0:
             # .pdata at 0x1000
-            yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + self.pdata_size
+            yield ".pdata", self.base_addr + PDATA_OFFSET, self.base_addr + PDATA_OFFSET + self.pdata_size
 
 
 class PdataExtractionTestSuite(unittest.TestCase):
@@ -32,23 +36,23 @@ class PdataExtractionTestSuite(unittest.TestCase):
         pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
         # Fill binary with zeros
-        binary_size = 0x4000
+        binary_size = BINARY_SIZE
         binary = bytearray(binary_size)
 
         # Place pdata at 0x1000
-        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
 
         # Initialize Mock Disassembly and BinaryInfo
         disasm = DisassemblyResult()
-        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
 
         fcm.init(disasm)
 
         candidates = fcm.candidates
 
-        self.assertIn(0x140000000 + 0x2000, candidates)
-        self.assertIn(0x140000000 + 0x2050, candidates)
-        self.assertIn(0x140000000 + 0x2100, candidates)
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertIn(BASE_ADDR + 0x2050, candidates)
+        self.assertIn(BASE_ADDR + 0x2100, candidates)
         self.assertEqual(len(candidates), 3)
 
     def test_pdata_with_zero_entry(self):
@@ -63,18 +67,18 @@ class PdataExtractionTestSuite(unittest.TestCase):
 
         pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
-        binary = bytearray(0x4000)
-        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+        binary = bytearray(BINARY_SIZE)
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
 
         disasm = DisassemblyResult()
-        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
 
         fcm.init(disasm)
 
         candidates = fcm.candidates
-        self.assertIn(0x140000000 + 0x2000, candidates)
-        self.assertNotIn(0x140000000 + 0x2100, candidates)
-        self.assertNotIn(0x140000000, candidates)
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertNotIn(BASE_ADDR + 0x2100, candidates)
+        self.assertNotIn(BASE_ADDR, candidates)
         self.assertEqual(len(candidates), 1)
 
     def test_pdata_misaligned_size(self):
@@ -88,16 +92,16 @@ class PdataExtractionTestSuite(unittest.TestCase):
         # Add some extra bytes to make it misaligned (not multiple of 12)
         pdata_bytes += b"\x90\x90"
 
-        binary = bytearray(0x4000)
-        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+        binary = bytearray(BINARY_SIZE)
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
 
         disasm = DisassemblyResult()
-        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
 
         fcm.init(disasm)
 
         candidates = fcm.candidates
-        self.assertIn(0x140000000 + 0x2000, candidates)
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
         self.assertEqual(len(candidates), 1)
 
 

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -72,9 +72,9 @@ class PdataExtractionTestSuite(unittest.TestCase):
 
         candidates = fcm.candidates
         self.assertIn(0x140000000 + 0x2000, candidates)
-        self.assertIn(0x140000000 + 0x2100, candidates)
+        self.assertNotIn(0x140000000 + 0x2100, candidates)
         self.assertNotIn(0x140000000, candidates)
-        self.assertEqual(len(candidates), 2)
+        self.assertEqual(len(candidates), 1)
 
     def test_pdata_misaligned_size(self):
         config = SmdaConfig()

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -7,7 +7,7 @@ from smda.SmdaConfig import SmdaConfig
 
 
 class MockBinaryInfo:
-    def __init__(self, bitness, base_addr, binary, pdata_size=36):
+    def __init__(self, bitness, base_addr, binary, pdata_size=0):
         self.bitness = bitness
         self.base_addr = base_addr
         self.binary = binary
@@ -16,8 +16,9 @@ class MockBinaryInfo:
 
     def getSections(self):
         # yields name, start, end
-        # .pdata at 0x1000
-        yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + self.pdata_size
+        if self.pdata_size > 0:
+            # .pdata at 0x1000
+            yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + self.pdata_size
 
 
 class PdataExtractionTestSuite(unittest.TestCase):
@@ -41,7 +42,7 @@ class PdataExtractionTestSuite(unittest.TestCase):
 
         # Initialize Mock Disassembly and BinaryInfo
         disasm = DisassemblyResult()
-        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary))
+        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
 
         fcm.init(disasm)
 
@@ -75,8 +76,9 @@ class PdataExtractionTestSuite(unittest.TestCase):
 
         candidates = fcm.candidates
         self.assertIn(0x140000000 + 0x2000, candidates)
-        self.assertNotIn(0x140000000 + 0x2100, candidates)
-        self.assertEqual(len(candidates), 1)
+        self.assertIn(0x140000000 + 0x2100, candidates)
+        self.assertNotIn(0x140000000, candidates)
+        self.assertEqual(len(candidates), 2)
 
     def test_pdata_misaligned_size(self):
         config = SmdaConfig()

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -5,9 +5,13 @@ from smda.DisassemblyResult import DisassemblyResult
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
 
+BASE_ADDR = 0x140000000
+BINARY_SIZE = 0x4000
+PDATA_OFFSET = 0x1000
+
 
 class MockBinaryInfo:
-    def __init__(self, bitness, base_addr, binary, pdata_size=36):
+    def __init__(self, bitness, base_addr, binary, pdata_size=0):
         self.bitness = bitness
         self.base_addr = base_addr
         self.binary = binary
@@ -16,8 +20,9 @@ class MockBinaryInfo:
 
     def getSections(self):
         # yields name, start, end
-        # .pdata at 0x1000
-        yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + self.pdata_size
+        if self.pdata_size > 0:
+            # .pdata at 0x1000
+            yield ".pdata", self.base_addr + PDATA_OFFSET, self.base_addr + PDATA_OFFSET + self.pdata_size
 
 
 class PdataExtractionTestSuite(unittest.TestCase):
@@ -28,28 +33,27 @@ class PdataExtractionTestSuite(unittest.TestCase):
         # Entry format: Start RVA, End RVA, Unwind RVA
         entries = [(0x2000, 0x2040, 0x3000), (0x2050, 0x2090, 0x3010), (0x2100, 0x2150, 0x3020)]
 
-        pdata_bytes = b""
-        for start, end, unwind in entries:
-            pdata_bytes += struct.pack("III", start, end, unwind)
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
         # Fill binary with zeros
-        binary_size = 0x4000
+        binary_size = BINARY_SIZE
         binary = bytearray(binary_size)
 
         # Place pdata at 0x1000
-        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
 
         # Initialize Mock Disassembly and BinaryInfo
         disasm = DisassemblyResult()
-        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary))
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
 
         fcm.init(disasm)
 
         candidates = fcm.candidates
 
-        self.assertIn(0x140000000 + 0x2000, candidates)
-        self.assertIn(0x140000000 + 0x2050, candidates)
-        self.assertIn(0x140000000 + 0x2100, candidates)
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertIn(BASE_ADDR + 0x2050, candidates)
+        self.assertIn(BASE_ADDR + 0x2100, candidates)
+        self.assertEqual(len(candidates), 3)
 
     def test_pdata_with_zero_entry(self):
         config = SmdaConfig()
@@ -61,21 +65,20 @@ class PdataExtractionTestSuite(unittest.TestCase):
             (0x2100, 0x2150, 0x3020),
         ]
 
-        pdata_bytes = b""
-        for start, end, unwind in entries:
-            pdata_bytes += struct.pack("III", start, end, unwind)
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
-        binary = bytearray(0x4000)
-        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+        binary = bytearray(BINARY_SIZE)
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
 
         disasm = DisassemblyResult()
-        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
 
         fcm.init(disasm)
 
         candidates = fcm.candidates
-        self.assertIn(0x140000000 + 0x2000, candidates)
-        self.assertNotIn(0x140000000 + 0x2100, candidates)
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertNotIn(BASE_ADDR + 0x2100, candidates)
+        self.assertNotIn(BASE_ADDR, candidates)
         self.assertEqual(len(candidates), 1)
 
     def test_pdata_misaligned_size(self):
@@ -84,23 +87,21 @@ class PdataExtractionTestSuite(unittest.TestCase):
 
         entries = [(0x2000, 0x2040, 0x3000)]
 
-        pdata_bytes = b""
-        for start, end, unwind in entries:
-            pdata_bytes += struct.pack("III", start, end, unwind)
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
 
         # Add some extra bytes to make it misaligned (not multiple of 12)
         pdata_bytes += b"\x90\x90"
 
-        binary = bytearray(0x4000)
-        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+        binary = bytearray(BINARY_SIZE)
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
 
         disasm = DisassemblyResult()
-        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary), pdata_size=len(pdata_bytes))
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
 
         fcm.init(disasm)
 
         candidates = fcm.candidates
-        self.assertIn(0x140000000 + 0x2000, candidates)
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
         self.assertEqual(len(candidates), 1)
 
 

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -1,0 +1,67 @@
+
+import unittest
+import struct
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
+
+class MockBinaryInfo:
+    def __init__(self, bitness, base_addr, binary):
+        self.bitness = bitness
+        self.base_addr = base_addr
+        self.binary = binary
+        self.code_areas = []
+
+    def getSections(self):
+        # yields name, start, end
+        # .pdata at 0x1000, size 36 (3 entries)
+        yield ".pdata", self.base_addr + 0x1000, self.base_addr + 0x1000 + 36
+
+class PdataExtractionTestSuite(unittest.TestCase):
+    def test_pdata_candidates(self):
+        config = SmdaConfig()
+        fcm = FunctionCandidateManager(config)
+
+        # Entry format: Start RVA, End RVA, Unwind RVA
+        entries = [
+            (0x2000, 0x2040, 0x3000),
+            (0x2050, 0x2090, 0x3010),
+            (0x2100, 0x2150, 0x3020)
+        ]
+
+        pdata_bytes = b""
+        for start, end, unwind in entries:
+            pdata_bytes += struct.pack("III", start, end, unwind)
+
+        # Fill binary with zeros
+        binary_size = 0x4000
+        binary = bytearray(binary_size)
+
+        # Place pdata at 0x1000
+        binary[0x1000 : 0x1000 + len(pdata_bytes)] = pdata_bytes
+
+        # Initialize Mock Disassembly and BinaryInfo
+        disasm = DisassemblyResult()
+        disasm.binary_info = MockBinaryInfo(64, 0x140000000, bytes(binary))
+
+        # Mock code_areas in binary info so passesCodeFilter works
+        # If code_areas is empty, it returns True (see FunctionCandidateManager.py)
+
+        # We need to mock LanguageAnalyzer to avoid it running on empty/random binary and potentially crashing or taking time
+        # But FunctionCandidateManager instantiates it inside init().
+        # We can mock it by assigning to fcm.lang_analyzer *after* init? No init calls identify().
+        # We can subclass FunctionCandidateManager and override init, or just mock disassembly.binary_info.binary to be safe for LanguageAnalyzer.
+        # LanguageAnalyzer checks bytes.
+
+        # Let's try running it. If LanguageAnalyzer crashes, we will see.
+
+        fcm.init(disasm)
+
+        candidates = fcm.candidates
+
+        self.assertIn(0x140000000 + 0x2000, candidates)
+        self.assertIn(0x140000000 + 0x2050, candidates)
+        self.assertIn(0x140000000 + 0x2100, candidates)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Implemented logic to extract function start candidates from `.pdata` section in `FunctionCandidateManager.py`.
- Iterates over `RUNTIME_FUNCTION` entries (12 bytes) and extracts the Start RVA.
- Corrected loop bounds to avoid out-of-bounds access.
- Removed TODO.
- Added regression test `tests/testPdataExtraction.py`.