### PR TITLE
feat: Add ELF section parsing to BinaryInfo

### DIFF
--- a/smda/common/BinaryInfo.py
+++ b/smda/common/BinaryInfo.py
@@ -37,10 +37,16 @@ class BinaryInfo:
         self.sha256 = hashlib.sha256(binary).hexdigest()
         self.sha1 = hashlib.sha1(binary).hexdigest()
         self.md5 = hashlib.md5(binary).hexdigest()
+        self._lief_binary = None
+
+    def _get_lief_binary(self):
+        if self._lief_binary is None:
+            self._lief_binary = lief.parse(self.raw_data)
+        return self._lief_binary
 
     def getOep(self):
         if self.oep is None:
-            lief_result = lief.parse(self.raw_data)
+            lief_result = self._get_lief_binary()
             if isinstance(lief_result, lief.PE.Binary):
                 self.oep = lief_result.optional_header.addressof_entrypoint
             elif isinstance(lief_result, lief.ELF.Binary):
@@ -49,7 +55,7 @@ class BinaryInfo:
 
     def getExportedFunctions(self):
         if self.exported_functions is None:
-            lief_result = lief.parse(self.raw_data)
+            lief_result = self._get_lief_binary()
             if isinstance(lief_result, lief.PE.Binary):
                 self.exported_functions = PeSymbolProvider(None).parseExports(lief_result)
             elif isinstance(lief_result, lief.ELF.Binary):
@@ -58,7 +64,7 @@ class BinaryInfo:
 
     def getImportedFunctions(self):
         if self.imported_functions is None:
-            lief_result = lief.parse(self.raw_data)
+            lief_result = self._get_lief_binary()
             if isinstance(lief_result, lief.PE.Binary):
                 PeSymbolProvider(None).parseSymbols(lief_result)
                 self.imported_functions = PeSymbolProvider(None).parseImports(lief_result)
@@ -68,7 +74,7 @@ class BinaryInfo:
 
     def getSymbols(self):
         if self.symbols is None:
-            lief_result = lief.parse(self.raw_data)
+            lief_result = self._get_lief_binary()
             if isinstance(lief_result, lief.PE.Binary):
                 self.symbols = PeSymbolProvider(None).parseSymbols(lief_result)
             elif isinstance(lief_result, lief.ELF.Binary):
@@ -76,21 +82,32 @@ class BinaryInfo:
         return self.symbols
 
     def getSections(self):
-        parsed_binary = lief.parse(self.raw_data)
-        if isinstance(parsed_binary, lief.PE.Binary) and parsed_binary.sections:
-            for section in parsed_binary.sections:
+        """
+        Generator that yields (name, start_addr, end_addr) for each section.
+        Supports PE and ELF binaries.
+        """
+        parsed_binary = self._get_lief_binary()
+        if not parsed_binary:
+            return
+
+        is_pe = isinstance(parsed_binary, lief.PE.Binary)
+        is_elf = isinstance(parsed_binary, lief.ELF.Binary)
+
+        if (not is_pe and not is_elf) or not parsed_binary.sections:
+            return
+
+        for section in parsed_binary.sections:
+            if is_pe:
                 section_start = self.base_addr + section.virtual_address
                 section_size = section.virtual_size
                 if section_size % 0x1000 != 0:
                     section_size += 0x1000 - (section_size % 0x1000)
-                section_end = section_start + section_size
-                yield section.name, section_start, section_end
-        elif isinstance(parsed_binary, lief.ELF.Binary) and parsed_binary.sections:
-            for section in parsed_binary.sections:
+            else:
                 section_start = section.virtual_address
                 section_size = section.size
-                section_end = section_start + section_size
-                yield section.name, section_start, section_end
+
+            section_end = section_start + section_size
+            yield section.name, section_start, section_end
 
     def isInCodeAreas(self, address):
         is_inside = False
@@ -104,7 +121,7 @@ class BinaryInfo:
 
     def getHeaderBytes(self):
         if self.raw_data:
-            lief_result = lief.parse(self.raw_data)
+            lief_result = self._get_lief_binary()
             if isinstance(lief_result, lief.PE.Binary):
                 return self.raw_data[:0x400]
             elif isinstance(lief_result, lief.ELF.Binary):

--- a/smda/common/BinaryInfo.py
+++ b/smda/common/BinaryInfo.py
@@ -93,7 +93,7 @@ class BinaryInfo:
         is_pe = isinstance(parsed_binary, lief.PE.Binary)
         is_elf = isinstance(parsed_binary, lief.ELF.Binary)
 
-        if (not is_pe and not is_elf) or not parsed_binary.sections:
+        if not (is_pe or is_elf) or not parsed_binary.sections:
             return
 
         for section in parsed_binary.sections:
@@ -102,7 +102,7 @@ class BinaryInfo:
                 section_size = section.virtual_size
                 if section_size % 0x1000 != 0:
                     section_size += 0x1000 - (section_size % 0x1000)
-            else:
+            elif is_elf:
                 section_start = section.virtual_address
                 section_size = section.size
 

--- a/smda/common/BinaryInfo.py
+++ b/smda/common/BinaryInfo.py
@@ -76,16 +76,19 @@ class BinaryInfo:
         return self.symbols
 
     def getSections(self):
-        pefile = lief.parse(self.raw_data)
-        # TODO 20201030 might want to add ELF sections as well
-        if not isinstance(pefile, lief.PE.Binary):
-            return
-        if pefile and pefile.sections:
-            for section in pefile.sections:
+        parsed_binary = lief.parse(self.raw_data)
+        if isinstance(parsed_binary, lief.PE.Binary) and parsed_binary.sections:
+            for section in parsed_binary.sections:
                 section_start = self.base_addr + section.virtual_address
                 section_size = section.virtual_size
                 if section_size % 0x1000 != 0:
                     section_size += 0x1000 - (section_size % 0x1000)
+                section_end = section_start + section_size
+                yield section.name, section_start, section_end
+        elif isinstance(parsed_binary, lief.ELF.Binary) and parsed_binary.sections:
+            for section in parsed_binary.sections:
+                section_start = section.virtual_address
+                section_size = section.size
                 section_end = section_start + section_size
                 yield section.name, section_start, section_end
 

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -83,6 +83,10 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         bashlite_unmapped_disassembly = disasm.disassembleUnmappedBuffer(bashlite_binary)
         assert bashlite_unmapped_disassembly.num_functions == 177
         assert len([f.function_name for f in bashlite_unmapped_disassembly.getFunctions() if f.function_name]) == 174
+        # test section extraction
+        sections = list(binary_info.getSections())
+        assert len(sections) > 0
+        assert any(name == ".text" for name, _, _ in sections)
 
     def testDotnetParsingWithNjRAT(self):
         disasm = Disassembler(config, backend="cil")

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -84,9 +84,9 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         assert bashlite_unmapped_disassembly.num_functions == 177
         assert len([f.function_name for f in bashlite_unmapped_disassembly.getFunctions() if f.function_name]) == 174
         # test section extraction
-        sections = list(binary_info.getSections())
+        sections = {name: (start, end) for name, start, end in binary_info.getSections()}
         assert len(sections) > 0
-        assert any(name == ".text" for name, _, _ in sections)
+        assert ".text" in sections
 
     def testDotnetParsingWithNjRAT(self):
         disasm = Disassembler(config, backend="cil")


### PR DESCRIPTION
Extends `BinaryInfo.getSections()` to support ELF binaries using LIEF. Unlike PE sections, ELF sections are used with their raw virtual address and size without 0x1000 alignment, as they are often packed tightly.

Modified `tests/testFileFormatParsers.py` to verify ELF section extraction using the existing `bashlite` sample.