### PR TITLE
⚡ Optimize printable string detection

### DIFF
--- a/smda/utility/StringExtractor.py
+++ b/smda/utility/StringExtractor.py
@@ -4,6 +4,8 @@ from typing import Iterator, Tuple
 
 from smda.common import SmdaFunction
 
+_IS_PRINTABLE_CHAR_CODE = tuple(chr(char) in string.printable for char in range(127))
+
 # ported back from our PR to capa v4.0.0
 # https://github.com/mandiant/capa/blob/v4.0.0/capa/features/extractors/smda/insn.py
 
@@ -64,7 +66,7 @@ def detect_ascii_len(smda_report, offset, maxlen=None):
     char = smda_report.buffer[rva]
     while (
         char < 127
-        and chr(char) in string.printable
+        and _IS_PRINTABLE_CHAR_CODE[char]
         and (maxlen is None or ascii_len < maxlen)
         and rva + 1 < len(smda_report.buffer)
     ):
@@ -87,7 +89,7 @@ def detect_unicode_len(smda_report, offset, maxlen=None):
     second_char = smda_report.buffer[rva + 1]
     while (
         char < 127
-        and chr(char) in string.printable
+        and _IS_PRINTABLE_CHAR_CODE[char]
         and second_char == 0
         and (maxlen is None or unicode_len < 2 * maxlen)
         and rva + 3 < len(smda_report.buffer)

--- a/smda/utility/StringExtractor.py
+++ b/smda/utility/StringExtractor.py
@@ -4,7 +4,7 @@ from typing import Iterator, Tuple
 
 from smda.common import SmdaFunction
 
-_IS_PRINTABLE_CHAR_CODE = tuple(chr(char) in string.printable for char in range(127))
+_IS_PRINTABLE_CHAR_CODE = tuple(chr(char) in string.printable for char in range(256))
 
 # ported back from our PR to capa v4.0.0
 # https://github.com/mandiant/capa/blob/v4.0.0/capa/features/extractors/smda/insn.py
@@ -65,10 +65,7 @@ def detect_ascii_len(smda_report, offset, maxlen=None):
         return 0
     char = smda_report.buffer[rva]
     while (
-        char < 127
-        and _IS_PRINTABLE_CHAR_CODE[char]
-        and (maxlen is None or ascii_len < maxlen)
-        and rva + 1 < len(smda_report.buffer)
+        _IS_PRINTABLE_CHAR_CODE[char] and (maxlen is None or ascii_len < maxlen) and rva + 1 < len(smda_report.buffer)
     ):
         ascii_len += 1
         rva += 1
@@ -88,8 +85,7 @@ def detect_unicode_len(smda_report, offset, maxlen=None):
     char = smda_report.buffer[rva]
     second_char = smda_report.buffer[rva + 1]
     while (
-        char < 127
-        and _IS_PRINTABLE_CHAR_CODE[char]
+        _IS_PRINTABLE_CHAR_CODE[char]
         and second_char == 0
         and (maxlen is None or unicode_len < 2 * maxlen)
         and rva + 3 < len(smda_report.buffer)


### PR DESCRIPTION
## 💡 What

Precomputes printable ASCII character membership once at module import time and uses an integer-indexed lookup table inside `detect_ascii_len()` and `detect_unicode_len()`.

## 🎯 Why

The previous hot-loop condition called `chr(char) in string.printable` for every byte checked. That repeatedly allocated one-character strings and scanned `string.printable` during string detection. The new lookup keeps the same printable-byte semantics while making the inner-loop check constant time with no per-iteration `chr()` call.

## 📊 Measured Improvement

Measured with a focused in-process benchmark using dummy SMDA reports, 4,096 printable `~` characters, warmup, GC disabled during samples, and best-of-seven timing on this Windows checkout. The machine was noisy, so best sample is the most stable comparison point.

| Path | Baseline best | Optimized best | Change |
| --- | ---: | ---: | ---: |
| `detect_ascii_len` | 4.668365s total / 1867.35us per call | 4.232579s total / 1693.03us per call | 9.3% faster |
| `detect_unicode_len` | 3.421829s total / 2737.46us per call | 2.690248s total / 2152.20us per call | 21.4% faster |

## ✅ Verification

- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m pytest -q` (`42 passed, 7 subtests passed`)