### PR TITLE
refactor(dalvik): address PR #31 review feedback on opcode decoder dispatch

### DIFF
--- a/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/smda/dalvik/DalvikOpcodeDecoder.py
@@ -444,46 +444,18 @@ FORMAT_DECODERS = {}
 
 
 def _decode_fmt_10x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
-    return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
-    }
+    return {}
 
 
 FORMAT_DECODERS["10x"] = _decode_fmt_10x
 
 
 def _decode_fmt_10t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     branch_delta = int.from_bytes(raw_bytes[1:2], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    operands = f"{hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "operands": f"{hex(branch_target_idx)}",
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
     }
 
 
@@ -491,25 +463,12 @@ FORMAT_DECODERS["10t"] = _decode_fmt_10t
 
 
 def _decode_fmt_11n(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     literal = _signed((raw_bytes[1] >> 4) & 0x0F, 4)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{literal:+d}",
     }
 
 
@@ -517,24 +476,10 @@ FORMAT_DECODERS["11n"] = _decode_fmt_11n
 
 
 def _decode_fmt_11x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
-    registers = [reg_a]
-    operands = _reg_name(reg_a)
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a],
+        "operands": _reg_name(reg_a),
     }
 
 
@@ -542,25 +487,11 @@ FORMAT_DECODERS["11x"] = _decode_fmt_11x
 
 
 def _decode_fmt_12x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}",
     }
 
 
@@ -568,24 +499,11 @@ FORMAT_DECODERS["12x"] = _decode_fmt_12x
 
 
 def _decode_fmt_20t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    operands = f"{hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "operands": f"{hex(branch_target_idx)}",
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
     }
 
 
@@ -593,25 +511,12 @@ FORMAT_DECODERS["20t"] = _decode_fmt_20t
 
 
 def _decode_fmt_21c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
+        "registers": [reg_a],
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -619,13 +524,6 @@ FORMAT_DECODERS["21c"] = _decode_fmt_21c
 
 
 def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     # The 16-bit immediate is sign-extended per the Dalvik spec before shifting.
     # Using signed=True ensures negative values like 0xFFFF produce -1 << shift
@@ -633,17 +531,10 @@ def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
     value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
     shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
     literal = value << shift
-    registers = [reg_a]
-    sign = "-" if literal < 0 else ""
-    operands = f"{_reg_name(reg_a)}, #{sign}{hex(abs(literal))}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{hex(literal)}",
     }
 
 
@@ -651,25 +542,12 @@ FORMAT_DECODERS["21h"] = _decode_fmt_21h
 
 
 def _decode_fmt_21s(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{literal:+d}",
     }
 
 
@@ -677,26 +555,13 @@ FORMAT_DECODERS["21s"] = _decode_fmt_21s
 
 
 def _decode_fmt_21t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, {hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "registers": [reg_a],
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {hex(branch_target_idx)}",
     }
 
 
@@ -704,26 +569,13 @@ FORMAT_DECODERS["21t"] = _decode_fmt_21t
 
 
 def _decode_fmt_22b(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     reg_b = raw_bytes[2]
     literal = int.from_bytes(raw_bytes[3:4], byteorder="little", signed=True)
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a, reg_b],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}",
     }
 
 
@@ -731,26 +583,13 @@ FORMAT_DECODERS["22b"] = _decode_fmt_22b
 
 
 def _decode_fmt_22c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
+        "registers": [reg_a, reg_b],
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -758,26 +597,13 @@ FORMAT_DECODERS["22c"] = _decode_fmt_22c
 
 
 def _decode_fmt_22s(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
     literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a, reg_b],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}",
     }
 
 
@@ -785,27 +611,14 @@ FORMAT_DECODERS["22s"] = _decode_fmt_22s
 
 
 def _decode_fmt_22t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "registers": [reg_a, reg_b],
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}",
     }
 
 
@@ -813,25 +626,11 @@ FORMAT_DECODERS["22t"] = _decode_fmt_22t
 
 
 def _decode_fmt_22x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     reg_b = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}",
     }
 
 
@@ -839,26 +638,12 @@ FORMAT_DECODERS["22x"] = _decode_fmt_22x
 
 
 def _decode_fmt_23x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     reg_b = raw_bytes[2]
     reg_c = raw_bytes[3]
-    registers = [reg_a, reg_b, reg_c]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b, reg_c],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}",
     }
 
 
@@ -866,24 +651,11 @@ FORMAT_DECODERS["23x"] = _decode_fmt_23x
 
 
 def _decode_fmt_30t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    operands = f"{hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "operands": f"{hex(branch_target_idx)}",
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
     }
 
 
@@ -891,25 +663,12 @@ FORMAT_DECODERS["30t"] = _decode_fmt_30t
 
 
 def _decode_fmt_31c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:6], byteorder="little")
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
+        "registers": [reg_a],
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -917,25 +676,12 @@ FORMAT_DECODERS["31c"] = _decode_fmt_31c
 
 
 def _decode_fmt_31i(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     literal = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{literal:+d}",
     }
 
 
@@ -943,26 +689,13 @@ FORMAT_DECODERS["31i"] = _decode_fmt_31i
 
 
 def _decode_fmt_31t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
     payload_idx = byte_idx + branch_delta
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
+        "registers": [reg_a],
         "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}",
     }
 
 
@@ -970,25 +703,11 @@ FORMAT_DECODERS["31t"] = _decode_fmt_31t
 
 
 def _decode_fmt_32x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = int.from_bytes(raw_bytes[2:4], byteorder="little")
     reg_b = int.from_bytes(raw_bytes[4:6], byteorder="little")
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}",
     }
 
 
@@ -996,24 +715,12 @@ FORMAT_DECODERS["32x"] = _decode_fmt_32x
 
 
 def _decode_fmt_35c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     _, registers = _decode_register_list_35c(raw_bytes)
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -1021,26 +728,14 @@ FORMAT_DECODERS["35c"] = _decode_fmt_35c
 
 
 def _decode_fmt_3rc(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     count = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
     registers = _decode_register_range(count, first_reg)
-    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -1048,29 +743,18 @@ FORMAT_DECODERS["3rc"] = _decode_fmt_3rc
 
 
 def _decode_fmt_45cc(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     _, registers = _decode_register_list_35c(raw_bytes[:6])
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-    operands = (
-        f"{{{_format_registers(registers)}}}, "
-        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
-        f"{resolve_ref('proto', ref_index_aux)}"
-    )
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
         "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": (
+            f"{{{_format_registers(registers)}}}, "
+            f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+            f"{resolve_ref('proto', ref_index_aux)}"
+        ),
     }
 
 
@@ -1078,31 +762,20 @@ FORMAT_DECODERS["45cc"] = _decode_fmt_45cc
 
 
 def _decode_fmt_4rcc(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     count = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
     registers = _decode_register_range(count, first_reg)
-    operands = (
-        f"{{{_format_registers(registers)}}}, "
-        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
-        f"{resolve_ref('proto', ref_index_aux)}"
-    )
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
         "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": (
+            f"{{{_format_registers(registers)}}}, "
+            f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+            f"{resolve_ref('proto', ref_index_aux)}"
+        ),
     }
 
 
@@ -1110,25 +783,12 @@ FORMAT_DECODERS["4rcc"] = _decode_fmt_4rcc
 
 
 def _decode_fmt_51l(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     literal = int.from_bytes(raw_bytes[2:10], byteorder="little", signed=True)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{hex(literal)}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{hex(literal)}",
     }
 
 
@@ -1160,14 +820,14 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
         size_units=opcode.size_units,
         size_bytes=size_bytes,
         bytes_=raw_bytes,
-        operands=result["operands"],
-        registers=result["registers"],
-        literal=result["literal"],
+        operands=result.get("operands", ""),
+        registers=result.get("registers", []),
+        literal=result.get("literal"),
         ref_kind=opcode.ref_kind,
-        ref_index=result["ref_index"],
-        ref_index_aux=result["ref_index_aux"],
-        branch_target_idx=result["branch_target_idx"],
-        payload_idx=result["payload_idx"],
+        ref_index=result.get("ref_index"),
+        ref_index_aux=result.get("ref_index_aux"),
+        branch_target_idx=result.get("branch_target_idx"),
+        payload_idx=result.get("payload_idx"),
         is_invoke=opcode.is_invoke,
         is_terminator=opcode.is_terminator,
         is_conditional=opcode.is_conditional,

--- a/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/smda/dalvik/DalvikOpcodeDecoder.py
@@ -451,7 +451,6 @@ def _decode_fmt_10x(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    operands = ""
     return {
         "registers": registers,
         "operands": operands,
@@ -499,8 +498,8 @@ def _decode_fmt_11n(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    literal = _signed(raw_bytes[1] >> 4 & 15, 4)
+    reg_a = raw_bytes[1] & 0x0F
+    literal = _signed((raw_bytes[1] >> 4) & 0x0F, 4)
     registers = [reg_a]
     operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
@@ -550,8 +549,8 @@ def _decode_fmt_12x(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     registers = [reg_a, reg_b]
     operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
@@ -628,6 +627,9 @@ def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
     branch_target_idx = None
     payload_idx = None
     reg_a = raw_bytes[1]
+    # The 16-bit immediate is sign-extended per the Dalvik spec before shifting.
+    # Using signed=True ensures negative values like 0xFFFF produce -1 << shift
+    # rather than 0xFFFF << shift, matching baksmali's output.
     value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
     shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
     literal = value << shift
@@ -736,8 +738,8 @@ def _decode_fmt_22c(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     registers = [reg_a, reg_b]
     operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
@@ -763,8 +765,8 @@ def _decode_fmt_22s(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
     registers = [reg_a, reg_b]
     operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
@@ -790,8 +792,8 @@ def _decode_fmt_22t(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
     registers = [reg_a, reg_b]
@@ -1056,8 +1058,10 @@ def _decode_fmt_45cc(raw_bytes, byte_idx, opcode, resolve_ref):
     _, registers = _decode_register_list_35c(raw_bytes[:6])
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-    operands = "{{{}}}, {}, {}".format(
-        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    operands = (
+        f"{{{_format_registers(registers)}}}, "
+        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+        f"{resolve_ref('proto', ref_index_aux)}"
     )
     return {
         "registers": registers,
@@ -1086,8 +1090,10 @@ def _decode_fmt_4rcc(raw_bytes, byte_idx, opcode, resolve_ref):
     first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
     registers = _decode_register_range(count, first_reg)
-    operands = "{{{}}}, {}, {}".format(
-        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    operands = (
+        f"{{{_format_registers(registers)}}}, "
+        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+        f"{resolve_ref('proto', ref_index_aux)}"
     )
     return {
         "registers": registers,
@@ -1140,27 +1146,12 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
         raise ValueError("Truncated Dalvik instruction")
 
     raw_bytes = bytes(bytecode[byte_idx : byte_idx + size_bytes])
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
 
-    if opcode.fmt not in FORMAT_DECODERS:
+    decoder = FORMAT_DECODERS.get(opcode.fmt)
+    if decoder is None:
         raise ValueError(f"Unsupported Dalvik format {opcode.fmt}")
 
-    decoder = FORMAT_DECODERS[opcode.fmt]
     result = decoder(raw_bytes, byte_idx, opcode, resolve_ref)
-
-    registers = result["registers"]
-    operands = result["operands"]
-    literal = result["literal"]
-    ref_index = result["ref_index"]
-    ref_index_aux = result["ref_index_aux"]
-    branch_target_idx = result["branch_target_idx"]
-    payload_idx = result["payload_idx"]
 
     return DecodedDalvikInstruction(
         opcode=opcode_value,
@@ -1169,14 +1160,14 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
         size_units=opcode.size_units,
         size_bytes=size_bytes,
         bytes_=raw_bytes,
-        operands=operands,
-        registers=registers,
-        literal=literal,
+        operands=result["operands"],
+        registers=result["registers"],
+        literal=result["literal"],
         ref_kind=opcode.ref_kind,
-        ref_index=ref_index,
-        ref_index_aux=ref_index_aux,
-        branch_target_idx=branch_target_idx,
-        payload_idx=payload_idx,
+        ref_index=result["ref_index"],
+        ref_index_aux=result["ref_index_aux"],
+        branch_target_idx=result["branch_target_idx"],
+        payload_idx=result["payload_idx"],
         is_invoke=opcode.is_invoke,
         is_terminator=opcode.is_terminator,
         is_conditional=opcode.is_conditional,

--- a/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/smda/dalvik/DalvikOpcodeDecoder.py
@@ -440,6 +440,695 @@ def _signed(value, bits):
     return (value & (sign_bit - 1)) - (value & sign_bit)
 
 
+FORMAT_DECODERS = {}
+
+
+def _decode_fmt_10x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    operands = ""
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["10x"] = _decode_fmt_10x
+
+
+def _decode_fmt_10t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    branch_delta = int.from_bytes(raw_bytes[1:2], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    operands = f"{hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["10t"] = _decode_fmt_10t
+
+
+def _decode_fmt_11n(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    literal = _signed(raw_bytes[1] >> 4 & 15, 4)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["11n"] = _decode_fmt_11n
+
+
+def _decode_fmt_11x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    registers = [reg_a]
+    operands = _reg_name(reg_a)
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["11x"] = _decode_fmt_11x
+
+
+def _decode_fmt_12x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["12x"] = _decode_fmt_12x
+
+
+def _decode_fmt_20t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    operands = f"{hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["20t"] = _decode_fmt_20t
+
+
+def _decode_fmt_21c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21c"] = _decode_fmt_21c
+
+
+def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
+    shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
+    literal = value << shift
+    registers = [reg_a]
+    sign = "-" if literal < 0 else ""
+    operands = f"{_reg_name(reg_a)}, #{sign}{hex(abs(literal))}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21h"] = _decode_fmt_21h
+
+
+def _decode_fmt_21s(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21s"] = _decode_fmt_21s
+
+
+def _decode_fmt_21t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, {hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21t"] = _decode_fmt_21t
+
+
+def _decode_fmt_22b(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    reg_b = raw_bytes[2]
+    literal = int.from_bytes(raw_bytes[3:4], byteorder="little", signed=True)
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22b"] = _decode_fmt_22b
+
+
+def _decode_fmt_22c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22c"] = _decode_fmt_22c
+
+
+def _decode_fmt_22s(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22s"] = _decode_fmt_22s
+
+
+def _decode_fmt_22t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22t"] = _decode_fmt_22t
+
+
+def _decode_fmt_22x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    reg_b = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22x"] = _decode_fmt_22x
+
+
+def _decode_fmt_23x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    reg_b = raw_bytes[2]
+    reg_c = raw_bytes[3]
+    registers = [reg_a, reg_b, reg_c]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["23x"] = _decode_fmt_23x
+
+
+def _decode_fmt_30t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    operands = f"{hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["30t"] = _decode_fmt_30t
+
+
+def _decode_fmt_31c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:6], byteorder="little")
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["31c"] = _decode_fmt_31c
+
+
+def _decode_fmt_31i(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    literal = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["31i"] = _decode_fmt_31i
+
+
+def _decode_fmt_31t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
+    payload_idx = byte_idx + branch_delta
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["31t"] = _decode_fmt_31t
+
+
+def _decode_fmt_32x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    reg_b = int.from_bytes(raw_bytes[4:6], byteorder="little")
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["32x"] = _decode_fmt_32x
+
+
+def _decode_fmt_35c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    _, registers = _decode_register_list_35c(raw_bytes)
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["35c"] = _decode_fmt_35c
+
+
+def _decode_fmt_3rc(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    count = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
+    registers = _decode_register_range(count, first_reg)
+    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["3rc"] = _decode_fmt_3rc
+
+
+def _decode_fmt_45cc(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    _, registers = _decode_register_list_35c(raw_bytes[:6])
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
+    operands = "{{{}}}, {}, {}".format(
+        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    )
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["45cc"] = _decode_fmt_45cc
+
+
+def _decode_fmt_4rcc(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    count = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
+    ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
+    registers = _decode_register_range(count, first_reg)
+    operands = "{{{}}}, {}, {}".format(
+        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    )
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["4rcc"] = _decode_fmt_4rcc
+
+
+def _decode_fmt_51l(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    literal = int.from_bytes(raw_bytes[2:10], byteorder="little", signed=True)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{hex(literal)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["51l"] = _decode_fmt_51l
+
+
 def decode_instruction(bytecode, byte_idx, resolve_ref):
     opcode_value = bytecode[byte_idx]
     if opcode_value not in OPCODES:
@@ -459,155 +1148,19 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
     branch_target_idx = None
     payload_idx = None
 
-    if opcode.fmt == "10x":
-        operands = ""
-    elif opcode.fmt == "10t":
-        branch_delta = int.from_bytes(raw_bytes[1:2], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        operands = f"{hex(branch_target_idx)}"
-    elif opcode.fmt == "11n":
-        reg_a = raw_bytes[1] & 0x0F
-        literal = _signed((raw_bytes[1] >> 4) & 0x0F, 4)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{literal:+d}"
-    elif opcode.fmt == "11x":
-        reg_a = raw_bytes[1]
-        registers = [reg_a]
-        operands = _reg_name(reg_a)
-    elif opcode.fmt == "12x":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
-    elif opcode.fmt == "20t":
-        branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        operands = f"{hex(branch_target_idx)}"
-    elif opcode.fmt == "21c":
-        reg_a = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "21h":
-        reg_a = raw_bytes[1]
-        # The 16-bit immediate is sign-extended per the Dalvik spec before shifting.
-        # Using signed=True ensures negative values like 0xFFFF produce -1 << shift
-        # rather than 0xFFFF << shift, matching baksmali's output.
-        value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-        shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
-        literal = value << shift
-        registers = [reg_a]
-        sign = "-" if literal < 0 else ""
-        operands = f"{_reg_name(reg_a)}, #{sign}{hex(abs(literal))}"
-    elif opcode.fmt == "21s":
-        reg_a = raw_bytes[1]
-        literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{literal:+d}"
-    elif opcode.fmt == "21t":
-        reg_a = raw_bytes[1]
-        branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, {hex(branch_target_idx)}"
-    elif opcode.fmt == "22b":
-        reg_a = raw_bytes[1]
-        reg_b = raw_bytes[2]
-        literal = int.from_bytes(raw_bytes[3:4], byteorder="little", signed=True)
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
-    elif opcode.fmt == "22c":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "22s":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
-    elif opcode.fmt == "22t":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}"
-    elif opcode.fmt == "22x":
-        reg_a = raw_bytes[1]
-        reg_b = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
-    elif opcode.fmt == "23x":
-        reg_a = raw_bytes[1]
-        reg_b = raw_bytes[2]
-        reg_c = raw_bytes[3]
-        registers = [reg_a, reg_b, reg_c]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}"
-    elif opcode.fmt == "30t":
-        branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        operands = f"{hex(branch_target_idx)}"
-    elif opcode.fmt == "31c":
-        reg_a = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:6], byteorder="little")
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "31i":
-        reg_a = raw_bytes[1]
-        literal = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{literal:+d}"
-    elif opcode.fmt == "31t":
-        reg_a = raw_bytes[1]
-        branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
-        payload_idx = byte_idx + branch_delta
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}"
-    elif opcode.fmt == "32x":
-        reg_a = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        reg_b = int.from_bytes(raw_bytes[4:6], byteorder="little")
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
-    elif opcode.fmt == "35c":
-        _, registers = _decode_register_list_35c(raw_bytes)
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "3rc":
-        count = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
-        registers = _decode_register_range(count, first_reg)
-        operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "45cc":
-        _, registers = _decode_register_list_35c(raw_bytes[:6])
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-        operands = "{{{}}}, {}, {}".format(
-            _format_registers(registers),
-            resolve_ref(opcode.ref_kind, ref_index),
-            resolve_ref("proto", ref_index_aux),
-        )
-    elif opcode.fmt == "4rcc":
-        count = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
-        ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-        registers = _decode_register_range(count, first_reg)
-        operands = "{{{}}}, {}, {}".format(
-            _format_registers(registers),
-            resolve_ref(opcode.ref_kind, ref_index),
-            resolve_ref("proto", ref_index_aux),
-        )
-    elif opcode.fmt == "51l":
-        reg_a = raw_bytes[1]
-        literal = int.from_bytes(raw_bytes[2:10], byteorder="little", signed=True)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{hex(literal)}"
-    else:
+    if opcode.fmt not in FORMAT_DECODERS:
         raise ValueError(f"Unsupported Dalvik format {opcode.fmt}")
+
+    decoder = FORMAT_DECODERS[opcode.fmt]
+    result = decoder(raw_bytes, byte_idx, opcode, resolve_ref)
+
+    registers = result["registers"]
+    operands = result["operands"]
+    literal = result["literal"]
+    ref_index = result["ref_index"]
+    ref_index_aux = result["ref_index_aux"]
+    branch_target_idx = result["branch_target_idx"]
+    payload_idx = result["payload_idx"]
 
     return DecodedDalvikInstruction(
         opcode=opcode_value,


### PR DESCRIPTION
Supersedes #31 by carrying the original dispatch-table refactor of `DalvikOpcodeDecoder` and applying two rounds of review feedback on top.

## Round 1 — PR #31 review comments

- **21h comment restored**: the rationale for `signed=True` sign-extension before shifting was dropped in the original refactor; re-added.
- **Nibble masks**: `15` → `0x0F` and `>> 4 & 15` → `(... >> 4) & 0x0F` across `11n`, `12x`, `22c`, `22s`, `22t` for readability and parity with the pre-refactor implementation.
- **`45cc` / `4rcc` operands**: switched from `str.format` to f-strings, matching every other decoder in the file.
- **`_decode_fmt_10x`**: removed the duplicate `operands = ""` assignment.
- **`decode_instruction`**: dropped the seven dead local initializations that were unconditionally overwritten from the decoder result dict.

## Round 2 — PR #33 review comments

- **Slim decoder contract**: each `_decode_fmt_*` now returns only the keys it sets. `decode_instruction` reads each field from the result with `dict.get(...)` and a sensible default. `_decode_fmt_10x` collapses to `return {}`.
- **`_decode_fmt_21h` sign handling**: dropped the manual `sign = "-" if literal < 0 else ""` branch — `hex(-65536)` already emits `-0x10000`, so `f"#{hex(literal)}"` produces identical output.

Net effect across both rounds: 340 fewer lines than the round-1 state, identical decoder behaviour.

## Verification

- `make test` — 80/80 pass
- `make lint` — clean
- `make format` (check) — clean
