### PR TITLE
build: update build tool constraints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 
 init:
-	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<75.4.0" wheel
+	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0,<0.48.0"
 	$(PYTHON) -m pip install -e ".[dev]"
 	$(PYTHON) -m pre_commit install
 package:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 
 init:
-	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0,<0.48.0"
+	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0"
 	$(PYTHON) -m pip install -e ".[dev]"
 	$(PYTHON) -m pre_commit install
 package:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and code form
 
 ```bash
 # Install development dependencies
-python3 -m pip install --upgrade pip "setuptools>=64.0.0,<75.4.0" wheel
+python3 -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0"
 python3 -m pip install -e ".[dev]"
 
 # Install pre-commit hooks (optional but recommended)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0,<75.4.0", "wheel"]
+requires = ["setuptools>=64.0.0,<82.1.0", "wheel>=0.47.0,<0.48.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0,<82.1.0", "wheel>=0.47.0,<0.48.0"]
+requires = ["setuptools>=64.0.0,<82.1.0", "wheel>=0.47.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary

- update the build-system `setuptools` constraint to allow the current PyPI release line
- pin `wheel` to the current PyPI release line used for local packaging validation
- keep `pyproject.toml` and the `make init` build-tool install path in sync

## Sources checked

- PyPI JSON metadata for `setuptools`: latest `82.0.1`
- PyPI JSON metadata for `wheel`: latest `0.47.0`

## Validation

- `make lint` -> passed
- `make test` -> 83 passed
- `make package` -> built `smda-3.0.1.tar.gz` and `smda-3.0.1-py3-none-any.whl`

## Notes

- `make package` with the latest `setuptools` reports existing license metadata deprecation warnings. This PR keeps that cleanup separate from the build-tool version update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system tooling dependencies to improve compatibility and stability with the latest tool versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/r0ny123/smda/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->