### PR TITLE
fix(core): address CodeRabbit runtime-safety findings

### DIFF
--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -26,6 +26,7 @@ class Disassembler:
             config = SmdaConfig()
         self.config = config
         self.disassembler = None
+        self._explicit_backend = bool(backend)
         if backend == "intel":
             self.disassembler = IntelDisassembler(self.config)
         elif backend == "cil":
@@ -136,8 +137,8 @@ class Disassembler:
                 self.disassembler.addPdbFile(binary_info, pdb_path)
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
-                is_go_binary = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
-                string_mode = "go" if is_go_binary else None
+                go_pclntab_offset = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
+                string_mode = "go" if go_pclntab_offset is not None else None
                 self._addStringsToReport(smda_report, binary_info.binary, mode=string_mode)
             if self.config.STORE_BUFFER:
                 smda_report.buffer = binary_info.binary
@@ -157,8 +158,8 @@ class Disassembler:
             self.initDisassembler(binary_info.architecture)
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
-                is_go_binary = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
-                string_mode = "go" if is_go_binary else None
+                go_pclntab_offset = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
+                string_mode = "go" if go_pclntab_offset is not None else None
                 self._addStringsToReport(smda_report, file_content, mode=string_mode)
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content
@@ -186,7 +187,7 @@ class Disassembler:
         # Auto-detect DEX when the caller did not explicitly override architecture.
         # disassembleUnmappedBuffer / disassembleFile already use FileLoader for detection;
         # this path bypasses it, so we check the magic bytes manually here.
-        if architecture == "intel" and DexFileLoader.isCompatible(file_content):
+        if not self._explicit_backend and architecture == "intel" and DexFileLoader.isCompatible(file_content):
             architecture = "dalvik"
             if bitness is None:
                 bitness = DexFileLoader.getBitness(file_content)
@@ -205,8 +206,8 @@ class Disassembler:
         try:
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
-                is_go_binary = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
-                string_mode = "go" if is_go_binary else None
+                go_pclntab_offset = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
+                string_mode = "go" if go_pclntab_offset is not None else None
                 self._addStringsToReport(smda_report, file_content, mode=string_mode)
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content

--- a/src/smda/DisassemblyStatistics.py
+++ b/src/smda/DisassemblyStatistics.py
@@ -8,6 +8,17 @@ class DisassemblyStatistics:
     num_function_calls = None
     num_failed_functions = None
     num_failed_instructions = None
+    _fields = (
+        "num_functions",
+        "num_recursive_functions",
+        "num_leaf_functions",
+        "num_basic_blocks",
+        "num_instructions",
+        "num_api_calls",
+        "num_function_calls",
+        "num_failed_functions",
+        "num_failed_instructions",
+    )
 
     def __init__(self, disassembly_result=None):
         if disassembly_result is not None:
@@ -74,13 +85,14 @@ class DisassemblyStatistics:
     def __add__(self, other):
         if not isinstance(other, DisassemblyStatistics):
             raise ValueError("Needs another DisassemblyStatistics to perform addition of values")
-        self.num_functions += other.num_functions
-        self.num_recursive_functions += other.num_recursive_functions
-        self.num_leaf_functions += other.num_leaf_functions
-        self.num_basic_blocks += other.num_basic_blocks
-        self.num_instructions += other.num_instructions
-        self.num_api_calls += other.num_api_calls
-        self.num_function_calls += other.num_function_calls
-        self.num_failed_functions += other.num_failed_functions
-        self.num_failed_instructions += other.num_failed_instructions
+        result = DisassemblyStatistics()
+        for field in self._fields:
+            setattr(result, field, (getattr(self, field) or 0) + (getattr(other, field) or 0))
+        return result
+
+    def __iadd__(self, other):
+        if not isinstance(other, DisassemblyStatistics):
+            raise ValueError("Needs another DisassemblyStatistics to perform addition of values")
+        for field in self._fields:
+            setattr(self, field, (getattr(self, field) or 0) + (getattr(other, field) or 0))
         return self

--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -156,21 +156,6 @@ class CilDisassembler:
             i_size = len(i_bytes)
             i_mnemonic = str(insn.opcode)
             i_op_str = format_operand(pe, insn.operand)
-            # debug output for all instructions
-            if False:
-                from smda.cil.CilInstructionEscaper import CilInstructionEscaper
-                from smda.common.SmdaInstruction import SmdaInstruction
-
-                smda_ins = SmdaInstruction([i_address, i_bytes.hex(), i_mnemonic, i_op_str])
-                escaped = CilInstructionEscaper.escapeBinary(smda_ins)
-                print(
-                    f"{escaped:<20}"
-                    + f"{insn.offset:04X}"
-                    + "    "
-                    + f"{' '.join(f'{b:02x}' for b in insn.get_bytes()): <20}"
-                    + f"{str(insn.opcode): <15}"
-                    + format_operand(pe, insn.operand)
-                )
             # https://en.wikipedia.org/wiki/List_of_CIL_instructions
             if i_mnemonic in ["ret"]:
                 state.setNextInstructionReachable(False)
@@ -211,12 +196,13 @@ class CilDisassembler:
                 target = int(i_op_str, 16)
                 state.addCodeRef(i_address, target, by_jump=True)
             if i_mnemonic in ["jmp"]:
-                raise Exception(
-                    "Found unhandled CIL jmp instruction, report back its structure and have Daniel fix it."
-                )
                 target = int(i_op_str, 16)
                 state.addCodeRef(i_address, target, by_jump=True)
                 state.setNextInstructionReachable(False)
+                LOGGER.error(
+                    "Found unhandled CIL jmp instruction at 0x%x, report back its structure and have Daniel fix it.",
+                    i_address,
+                )
             if i_mnemonic in ["ldstr"]:
                 # we possibly want to extract and collect these and put them in the stringref part of SmdaFunction
                 self.disassembly.addStringRef(start_addr, i_address, i_op_str[1:-1])
@@ -276,6 +262,6 @@ class CilDisassembler:
             self.analyzeFunction(pe, method_body.offset, method_body)
         # package up and finish
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
-        if cbAnalysisTimeout():
+        if cbAnalysisTimeout and cbAnalysisTimeout():
             self.disassembly.analysis_timeout = True
         return self.disassembly

--- a/src/smda/cil/CilInstructionEscaper.py
+++ b/src/smda/cil/CilInstructionEscaper.py
@@ -303,7 +303,6 @@ class CilInstructionEscaper:
                 mnemonic,
             )
             return "U"
-        return mnemonic
 
     @staticmethod
     def escapeField(op_field, escape_registers=True, escape_pointers=True, escape_constants=True):
@@ -451,6 +450,7 @@ class CilInstructionEscaper:
                 "brtrue",
                 "brtrue.s",
                 "brzero",
+                "brzero.s",
                 "switch",
             ]:
                 escaped_sequence = CilInstructionEscaper.escapeToOpcodeOnly(ins)

--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -133,7 +133,6 @@ class FunctionAnalysisState:
                     and i != len(self.instructions) - 1
                     and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
                 ):
-                    break
                     # if we can reach a colliding address from here, the block is broken and should end.
                     reachable_collisions = self.code_refs_from[current[0]].intersection(self.colliding_addresses)
                     next_addr = current[0] + current[1]
@@ -141,7 +140,7 @@ class FunctionAnalysisState:
                     if reachable_collisions and is_next_addr:
                         # we should remove the from/to code references for this collision as there should be no non CFG instruction references between instructions of different functions
                         self.removeCodeRef(current[0], next_addr)
-                        break
+                    break
                 if (
                     i != len(self.instructions) - 1
                     and self.instructions[i + 1][0] in self.code_refs_to

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -17,7 +17,7 @@ class BinaryInfo:
     raw_data = b""
     binary_size = 0
     bitness = None
-    code_areas = []
+    code_areas = None
     component = ""
     family = ""
     file_path = ""
@@ -36,6 +36,7 @@ class BinaryInfo:
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)
+        self.code_areas = []
         self._lief_binary = None
         self.abi = ""
 

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -16,14 +16,18 @@ class SmdaBasicBlock:
     def __init__(self, instructions, smda_function=None):
         assert isinstance(instructions, list)
         self.smda_function = smda_function
+        self.instructions = instructions
+        self.offset = instructions[0].offset if instructions else None
+        self.length = len(instructions)
+        self.picblockhash = None
+        self.opcblockhash = None
         if instructions:
-            self.instructions = instructions
-            self.offset = instructions[0].offset
-            self.length = len(instructions)
             self.picblockhash = self.getPicBlockHash()
             self.opcblockhash = self.getOpcBlockHash()
 
     def getInstructions(self) -> Iterator["SmdaInstruction"]:
+        if self.instructions is None:
+            return
         yield from self.instructions
 
     def getPicBlockHash(self):
@@ -90,12 +94,11 @@ class SmdaBasicBlock:
 
     @classmethod
     def fromDict(cls, block_dict, smda_function=None) -> "SmdaBasicBlock":
-        smda_block = cls(None)
-        smda_block.smda_function = smda_function
-        smda_block.instructions = [SmdaInstruction.fromDict(d, smda_function=smda_function) for d in block_dict]
-        return smda_block
+        return cls([SmdaInstruction.fromDict(d, smda_function=smda_function) for d in block_dict], smda_function)
 
     def toDict(self) -> dict:
+        if self.instructions is None:
+            return []
         return [smda_ins.toDict() for smda_ins in self.instructions]
 
     def __int__(self):

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -35,7 +35,7 @@ class SmdaBasicBlock:
             return self.picblockhash
         picblockhash_sequence = self.getPicBlockHashSequence()
         if picblockhash_sequence is not None:
-            self.picblockhash = struct.unpack("Q", hashlib.sha256(picblockhash_sequence).digest()[:8])[0]
+            self.picblockhash = struct.unpack("<Q", hashlib.sha256(picblockhash_sequence).digest()[:8])[0]
         return self.picblockhash
 
     def getPicBlockHashSequence(self):
@@ -66,7 +66,7 @@ class SmdaBasicBlock:
             return self.opcblockhash
         opcblockhash_sequence = self.getOpcBlockHashSequence()
         if opcblockhash_sequence is not None:
-            self.opcblockhash = struct.unpack("Q", hashlib.sha256(opcblockhash_sequence).digest()[:8])[0]
+            self.opcblockhash = struct.unpack("<Q", hashlib.sha256(opcblockhash_sequence).digest()[:8])[0]
         return self.opcblockhash
 
     def getOpcBlockHashSequence(self):
@@ -105,4 +105,6 @@ class SmdaBasicBlock:
         return self.offset
 
     def __str__(self):
+        if self.offset is None:
+            return f"0x????????: ({self.length:>4})"
         return f"0x{self.offset:08x}: ({self.length:>4})"

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -36,11 +36,13 @@ class SmdaFunction:
     function_name = ""
     pic_hash = None
     opc_hash = None
+    nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
+        self.nesting_depth = 0
         if disassembly is not None and function_offset is not None:
             self._escaper = IntelInstructionEscaper if disassembly.binary_info.architecture in ["intel"] else None
             self.offset = function_offset
@@ -72,14 +74,11 @@ class SmdaFunction:
             # DEX strings are part of the parsed file structure, so they're always
             # populated for Dalvik regardless of WITH_STRINGS — no extra extraction
             # cost. For other architectures, honor WITH_STRINGS as usual.
-            if (
-                config
-                and config.WITH_STRINGS
-                or (
-                    disassembly.binary_info.architecture == "dalvik"
-                    and disassembly.getStringRefsForFunction(function_offset)
-                )
-            ):
+            is_dalvik_with_strings = (
+                disassembly.binary_info.architecture == "dalvik"
+                and disassembly.getStringRefsForFunction(function_offset)
+            )
+            if (config and config.WITH_STRINGS) or is_dalvik_with_strings:
                 self.stringrefs = (
                     self._normalizeDalvikStringRefs(disassembly.getStringRefsForFunction(function_offset))
                     if disassembly.binary_info.architecture == "dalvik"
@@ -145,7 +144,7 @@ class SmdaFunction:
         return self.pic_hash
 
     def getPicHashAsHex(self):
-        return struct.pack("l", self.pic_hash).hex()
+        return struct.pack("Q", self.pic_hash).hex()
 
     def getInstructions(self):
         for block in self.getBlocks():

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -144,7 +144,7 @@ class SmdaFunction:
         return self.pic_hash
 
     def getPicHashAsHex(self):
-        return struct.pack("Q", self.pic_hash).hex()
+        return struct.pack("<Q", self.pic_hash).hex()
 
     def getInstructions(self):
         for block in self.getBlocks():
@@ -186,7 +186,7 @@ class SmdaFunction:
         return nesting_depth
 
     def getPicHash(self, binary_info):
-        return struct.unpack("Q", hashlib.sha256(self.getPicHashSequence(binary_info)).digest()[:8])[0]
+        return struct.unpack("<Q", hashlib.sha256(self.getPicHashSequence(binary_info)).digest()[:8])[0]
 
     def getPicHashSequence(self, binary_info):
         escaped_binary_seqs = []
@@ -203,7 +203,7 @@ class SmdaFunction:
         return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
 
     def getOpcHash(self):
-        return struct.unpack("Q", hashlib.sha256(self.getOpcHashSequence()).digest()[:8])[0]
+        return struct.unpack("<Q", hashlib.sha256(self.getOpcHashSequence()).digest()[:8])[0]
 
     def getOpcHashSequence(self):
         escaped_binary_seqs = []

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -75,7 +75,7 @@ class SmdaInstruction:
             # WAIT instruction before the wait version and the NOP instruction
             # before the no-wait version.
             if len(with_details) > 1:
-                LOGGER.warn(
+                LOGGER.warning(
                     f"Sequence {self.bytes} disassembles to {len(with_details)} instructions but expected one - taking the last instruction only!"
                 )
                 self.detailed = with_details[-1]

--- a/src/smda/common/TailcallAnalyzer.py
+++ b/src/smda/common/TailcallAnalyzer.py
@@ -1,9 +1,12 @@
 import bisect
 import json
+import logging
 from collections import defaultdict
 from operator import itemgetter
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TailcallAnalyzer:
@@ -87,15 +90,15 @@ class TailcallAnalyzer:
         # return
         if len(intervals) < 25:
             for one, two in intervals:
-                print(f"  0x{one:x} -> 0x{two:x}")
+                LOGGER.debug("  0x%x -> 0x%x", one, two)
         else:
-            print("Function has too many intervals to display")
+            LOGGER.debug("Function has too many intervals to display")
 
     def resolveTailcalls(self, disassembler, verbose=False):
         newly_created_functions = set()
         for tailcall in self.getTailcalls():
             if verbose:
-                print(f"Processing tailcall:\n{json.dumps(tailcall, indent=2, sort_keys=True)}")
+                LOGGER.debug("Processing tailcall:\n%s", json.dumps(tailcall, indent=2, sort_keys=True))
             # remove the information from the function-analysis state of the disassembly
             function = self.__getFunctionByStartAddr(tailcall["destination_function"])
             if not function or function.is_tailcall_function:
@@ -105,7 +108,7 @@ class TailcallAnalyzer:
             self.__functions.remove(function)
             if function:
                 if verbose:
-                    print("Old function:")
+                    LOGGER.debug("Old function:")
                     self.__printIntervals(self.__getFunctionIntervals(function))
                 function.revertAnalysis()
 
@@ -123,7 +126,7 @@ class TailcallAnalyzer:
                     reraise_non_operational_exception(exc)
                     # print ("0x{:x} -> 0x{:x}".format(tailcall["destination_function"], tailcall["destination_addr"]))
             elif verbose:
-                print(
+                LOGGER.debug(
                     "**** 0x{:x} IS NOW PART OF 0x{:x}".format(
                         tailcall["destination_function"], tailcall["destination_addr"]
                     )
@@ -132,10 +135,10 @@ class TailcallAnalyzer:
             if verbose:
                 function = self.__getFunctionByStartAddr(tailcall["destination_function"])
                 new_function = self.__getFunctionByStartAddr(tailcall["destination_addr"])
-                print("New function:")
+                LOGGER.debug("New function:")
                 if new_function:
                     self.__printIntervals(self.__getFunctionIntervals(new_function))
-                print("Re-disassembled old function:")
+                LOGGER.debug("Re-disassembled old function:")
                 if function:
                     self.__printIntervals(self.__getFunctionIntervals(function))
         return sorted(newly_created_functions)

--- a/src/smda/common/labelprovider/AbstractLabelProvider.py
+++ b/src/smda/common/labelprovider/AbstractLabelProvider.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python
 
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 LOGGER = logging.getLogger(__name__)
 
 
-class AbstractLabelProvider:
+class AbstractLabelProvider(ABC):
     def __init__(self, config):
-        raise NotImplementedError
+        self._config = config
 
     @abstractmethod
     def update(self, binary_info):
@@ -16,7 +16,7 @@ class AbstractLabelProvider:
         raise NotImplementedError
 
     @abstractmethod
-    def getApi(self, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         """If the LabelProvider has any information about a used API for the given address, return (dll, api), else return None"""
         raise NotImplementedError
 

--- a/src/smda/common/labelprovider/CilSymbolProvider.py
+++ b/src/smda/common/labelprovider/CilSymbolProvider.py
@@ -34,6 +34,8 @@ class CilSymbolProvider(AbstractLabelProvider):
         return value.encode("utf-8").decode("utf-8")
 
     def update(self, binary_info):
+        self._addr_to_func_symbols = {}
+        self._func_symbol_to_addr = {}
         try:
             pe = dnfile.dnPE(data=binary_info.raw_data)
         except Exception as exc:

--- a/src/smda/common/labelprovider/CilSymbolProvider.py
+++ b/src/smda/common/labelprovider/CilSymbolProvider.py
@@ -4,6 +4,8 @@ import logging
 
 import dnfile
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 
 LOGGER = logging.getLogger(__name__)
@@ -21,13 +23,29 @@ class CilSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def decodeSymbolName(self, value):
         """ensure a proper utf-8 escaped string"""
         return value.encode("utf-8").decode("utf-8")
 
     def update(self, binary_info):
-        pe = dnfile.dnPE(data=binary_info.raw_data)
-        for row in pe.net.mdtables.MethodDef:
+        try:
+            pe = dnfile.dnPE(data=binary_info.raw_data)
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
+            LOGGER.debug("Failed to parse CIL symbols: %s", exc)
+            return
+        if not getattr(pe, "net", None) or not getattr(pe.net, "mdtables", None):
+            return
+        method_defs = getattr(pe.net.mdtables, "MethodDef", None)
+        if not method_defs:
+            return
+        for row in method_defs:
             addr = pe.get_offset_from_rva(row.Rva)
             func_name = self.decodeSymbolName(row.Name.value)
             self._addr_to_func_symbols[addr] = func_name

--- a/src/smda/common/labelprovider/DelphiKbSymbolProvider.py
+++ b/src/smda/common/labelprovider/DelphiKbSymbolProvider.py
@@ -28,6 +28,12 @@ class DelphiKbSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def getSymbol(self, address):
         return self._func_symbols.get(address, "")
 
@@ -58,8 +64,14 @@ class DelphiKbSymbolProvider(AbstractLabelProvider):
         temp_off = fh.tell()
         for modID in modules:
             fh.seek(modules[modID]["offset"])
-            if modID != int.from_bytes(fh.read(2), byteorder="little"):
-                print("ModID doesnt match" + str(modules[modID]["offset"]))
+            actual_mod_id = int.from_bytes(fh.read(2), byteorder="little")
+            if modID != actual_mod_id:
+                LOGGER.warning(
+                    "ModID mismatch at offset 0x%x: expected %d, got %d",
+                    modules[modID]["offset"],
+                    modID,
+                    actual_mod_id,
+                )
             len_name = int.from_bytes(fh.read(2), byteorder="little")
             modules[modID]["name"] = fh.read(len_name).decode()
             modules[modID]["functions"] = []

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -476,7 +476,7 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def isApiProvider(self):
         return False
 
-    def getApi(self, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         return None
 
     def getSymbol(self, address):

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -686,7 +686,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def isApiProvider(self):
         return False
 
-    def getApi(self, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         return None
 
     def getSymbol(self, address):

--- a/src/smda/common/labelprovider/ElfApiResolver.py
+++ b/src/smda/common/labelprovider/ElfApiResolver.py
@@ -50,7 +50,16 @@ class ElfApiResolver(AbstractLabelProvider):
         """Returns whether the get_api(..) function of the AbstractLabelProvider is functional"""
         return True
 
-    def getApi(self, to_addr, absolute_addr):
+    def isSymbolProvider(self):
+        return False
+
+    def getSymbol(self, address):
+        return ""
+
+    def getFunctionSymbols(self):
+        return {}
+
+    def getApi(self, to_addr, absolute_addr=None):
         """
         If the LabelProvider has any information about a used API for the given address, return (dll, api), else return (None, None).
 

--- a/src/smda/common/labelprovider/ElfApiResolver.py
+++ b/src/smda/common/labelprovider/ElfApiResolver.py
@@ -66,5 +66,7 @@ class ElfApiResolver(AbstractLabelProvider):
         May return None for the `dll` if it cannot be determined.
         When it can be determined for ELF files, the `dll` field should be interpreted as the API version rather than shared library name.
         For example: "GLIBC_2.2.5".
+        `absolute_addr` is part of the label-provider API but intentionally unused here:
+        ELF lookups are keyed by relocation slot address (`to_addr`) in `_api_map["lief"]`.
         """
         return self._api_map["lief"].get(to_addr, (None, None))

--- a/src/smda/common/labelprovider/ElfSymbolProvider.py
+++ b/src/smda/common/labelprovider/ElfSymbolProvider.py
@@ -21,6 +21,12 @@ class ElfSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def _parseOep(self, lief_result):
         if lief_result:
             self._func_symbols[lief_result.header.entrypoint] = "original_entry_point"

--- a/src/smda/common/labelprovider/GoLabelProvider.py
+++ b/src/smda/common/labelprovider/GoLabelProvider.py
@@ -26,13 +26,20 @@ class GoSymbolProvider(AbstractLabelProvider):
         pclntab_offset = None
         try:
             lief_binary = lief.parse(binary)
-            if lief_binary.format == lief.EXE_FORMATS.ELF:
-                pclntab_offset = lief_binary.get_section(".gopclntab").offset
-            elif lief_binary.format == lief.EXE_FORMATS.MACHO:
-                pclntab_offset = lief_binary.get_section("__gopclntab").offset
-            elif lief_binary.format == lief.EXE_FORMATS.PE:
-                rdata_offset = lief_binary.get_section(".rdata").offset
-                pclntab_offset = rdata_offset + lief_binary.get_symbol("runtime.pclntab").value
+            if lief_binary is not None:
+                if lief_binary.format == lief.EXE_FORMATS.ELF:
+                    section = lief_binary.get_section(".gopclntab")
+                    if section is not None:
+                        pclntab_offset = section.offset
+                elif lief_binary.format == lief.EXE_FORMATS.MACHO:
+                    section = lief_binary.get_section("__gopclntab")
+                    if section is not None:
+                        pclntab_offset = section.offset
+                elif lief_binary.format == lief.EXE_FORMATS.PE:
+                    section = lief_binary.get_section(".rdata")
+                    symbol = lief_binary.get_symbol("runtime.pclntab")
+                    if section is not None and symbol is not None:
+                        pclntab_offset = section.offset + symbol.value
         except Exception as exc:
             reraise_non_operational_exception(exc)
         if pclntab_offset is None:
@@ -41,13 +48,13 @@ class GoSymbolProvider(AbstractLabelProvider):
             hits = [match.start() for match in re.finditer(pclntab_regex, binary)]
             if len(hits) == 1:
                 pclntab_offset = hits[0]
-        return pclntab_offset is not None
+        return pclntab_offset
 
     def update(self, binary_info):
         binary = binary_info.binary
         pclntab_offset = self.getPcLntabOffset(binary)
         # if we found a valid offset, do the pclntab parsing
-        if pclntab_offset:
+        if pclntab_offset is not None:
             try:
                 result = self._parse_pclntab(pclntab_offset, binary)
                 if result:
@@ -58,6 +65,12 @@ class GoSymbolProvider(AbstractLabelProvider):
 
     def isSymbolProvider(self):
         return True
+
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
 
     def getSymbol(self, address):
         return self._func_symbols.get(address, "")
@@ -111,7 +124,6 @@ class GoSymbolProvider(AbstractLabelProvider):
             parsed_pclntab_fields = struct.unpack(7 * field_indicator, pclntab_buffer[8 : 8 + 7 * field_size])
             number_of_functions = parsed_pclntab_fields[0]
             function_name_offset = pclntab_offset + parsed_pclntab_fields[2]
-            pclntab_offset + parsed_pclntab_fields[3]
             weird_table_offset = pclntab_offset + parsed_pclntab_fields[6]
             start_text = 0
         elif version == "1.18" or version == "1.20":
@@ -119,7 +131,6 @@ class GoSymbolProvider(AbstractLabelProvider):
             number_of_functions = parsed_pclntab_fields[0]
             start_text = parsed_pclntab_fields[2]
             function_name_offset = pclntab_offset + parsed_pclntab_fields[3]
-            pclntab_offset + parsed_pclntab_fields[5]
             weird_table_offset = pclntab_offset + parsed_pclntab_fields[7]
 
         # first parse function offsets

--- a/src/smda/common/labelprovider/PdbSymbolProvider.py
+++ b/src/smda/common/labelprovider/PdbSymbolProvider.py
@@ -36,6 +36,12 @@ class PdbSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def _parseOep(self, data):
         oep_rva = PeFileLoader.getOEP(data)
         if oep_rva:

--- a/src/smda/common/labelprovider/PeSymbolProvider.py
+++ b/src/smda/common/labelprovider/PeSymbolProvider.py
@@ -24,6 +24,12 @@ class PeSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def _parseOep(self, lief_result):
         if lief_result:
             self._func_symbols[lief_result.entrypoint] = "original_entry_point"
@@ -61,7 +67,7 @@ class PeSymbolProvider(AbstractLabelProvider):
                 code_base_address = lief_binary.imagebase + section.virtual_address
                 break
         if code_base_address is None:
-            return
+            return function_symbols
         for symbol in lief_binary.symbols:
             if hasattr(symbol.complex_type, "name") and symbol.complex_type.name == "FUNCTION":
                 function_name = ""

--- a/src/smda/common/labelprovider/WinApiResolver.py
+++ b/src/smda/common/labelprovider/WinApiResolver.py
@@ -91,7 +91,7 @@ class WinApiResolver(AbstractLabelProvider):
         """Returns whether the get_api(..) function of the AbstractLabelProvider is functional"""
         return True
 
-    def getApi(self, to_addr, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         """If the LabelProvider has any information about a used API for the given address, return (dll, api), else return (None, None)"""
         # if we work on a dump, use ApiScout method:
         if self._is_buffer:
@@ -102,3 +102,12 @@ class WinApiResolver(AbstractLabelProvider):
         # otherwise take import table info from LIEF
         else:
             return self._api_map["lief"].get(to_addr, (None, None))
+
+    def isSymbolProvider(self):
+        return False
+
+    def getSymbol(self, address):
+        return ""
+
+    def getFunctionSymbols(self):
+        return {}

--- a/src/smda/common/labelprovider/rust_demangler/rust_legacy.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_legacy.py
@@ -17,7 +17,10 @@ class LegacyDemangler:
     def demangle(self, inpstr: str) -> str:
         self.elements = 0
 
+        original_inpstr = inpstr
         disp = ""
+        if "N" not in inpstr:
+            raise UnableToLegacyDemangle(original_inpstr)
         inpstr = inpstr[inpstr.index("N") + 1 :]
         self.sanity_check(inpstr)
 
@@ -26,7 +29,7 @@ class LegacyDemangler:
             candidate = inpstr[length + 6 :]
             for i in candidate:
                 if i not in string.hexdigits + "@":
-                    raise UnableToLegacyDemangle(inpstr)
+                    raise UnableToLegacyDemangle(original_inpstr)
             inpstr = inpstr[:length]
 
         inn = inpstr
@@ -69,25 +72,34 @@ class LegacyDemangler:
 
                 elif rest.startswith("$"):
                     end = rest[1:].find("$")
+                    if end == -1:
+                        raise UnableToLegacyDemangle(original_inpstr)
                     escape = rest[1 : end + 1]
                     after_escape = rest[end + 2 :]
+                    if not escape:
+                        raise UnableToLegacyDemangle(original_inpstr)
 
                     if escape.startswith("u"):
                         digits = escape[1:]
+                        if not digits:
+                            raise UnableToLegacyDemangle(original_inpstr)
 
                         for i in digits:
                             if i not in string.hexdigits:
-                                raise UnableToLegacyDemangle(inpstr)
+                                raise UnableToLegacyDemangle(original_inpstr)
 
-                        c = int(digits, 16)
-                        disp += chr(c)
+                        try:
+                            c = int(digits, 16)
+                            disp += chr(c)
+                        except (OverflowError, ValueError):
+                            raise UnableToLegacyDemangle(original_inpstr) from None
 
                         rest = after_escape
                         continue
 
                     else:
                         if escape not in self._UNESCAPED:
-                            raise UnableToLegacyDemangle(inpstr)
+                            raise UnableToLegacyDemangle(original_inpstr)
                         disp += self._UNESCAPED[escape]
                         rest = after_escape
                         continue
@@ -95,11 +107,6 @@ class LegacyDemangler:
                 elif ("$") in rest:
                     dollar = rest.find("$")
                     dot = rest.find(".")
-
-                    if dollar == -1:
-                        disp += rest[:dot]
-                        rest = rest[dot:]
-                        continue
 
                     if dot == -1:
                         disp += rest[:dollar]

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -23,6 +23,8 @@ class V0Demangler:
         self.suffix = ""
         self.disp = ""
 
+        if "R" not in inpstr:
+            raise UnableTov0Demangle(inpstr)
         self.inpstr = inpstr[inpstr.index("R") + 1 :]
         self.sanity_check(self.inpstr)
 
@@ -735,17 +737,24 @@ class Printer:
             self.recursion -= 1
 
     def print_path_maybe_open_generics(self):
-        if self.eat("B"):
-            return self.backref_printer().print_path_maybe_open_generics()
+        self.check_recursion_limit()
+        try:
+            if self.eat("B"):
+                prin = self.backref_printer()
+                result = prin.print_path_maybe_open_generics()
+                self.out = prin.out
+                return result
 
-        elif self.eat("I"):
-            self.print_path(False)
-            self.out += "<"
-            self.print_sep_list("print_generic_arg", ", ")
-            return True
-        else:
-            self.print_path(False)
-            return False
+            elif self.eat("I"):
+                self.print_path(False)
+                self.out += "<"
+                self.print_sep_list("print_generic_arg", ", ")
+                return True
+            else:
+                self.print_path(False)
+                return False
+        finally:
+            self.recursion -= 1
 
     def print_dyn_trait(self):
         open = self.print_path_maybe_open_generics()
@@ -828,5 +837,8 @@ class Printer:
 
         char_val = "0x"
         char_val += hex_val
-        c = chr(int(char_val, 16))
+        try:
+            c = chr(int(char_val, 16))
+        except (OverflowError, ValueError):
+            self.invalid()
         self.out += repr(c)

--- a/src/smda/ida/IdaExporter.py
+++ b/src/smda/ida/IdaExporter.py
@@ -1,10 +1,13 @@
 import datetime
+import logging
 
 from capstone import CS_ARCH_X86, CS_MODE_32, CS_MODE_64, Cs
 
 from smda.DisassemblyResult import DisassemblyResult
 
 from .IdaInterface import IdaInterface
+
+LOGGER = logging.getLogger(__name__)
 
 
 class IdaExporter:
@@ -30,7 +33,7 @@ class IdaExporter:
         else:
             # record error and emit placeholder instruction
             bytes_as_hex = "".join([f"{c:02x}" for c in bytearray(instruction_bytes)])
-            print(f"missing capstone disassembly output at 0x{offset:x} ({bytes_as_hex})")
+            LOGGER.warning("missing capstone disassembly output at 0x%x (%s)", offset, bytes_as_hex)
             self.disassembly.errors[offset] = {
                 "type": "capstone disassembly failure",
                 "instruction_bytes": bytes_as_hex,

--- a/src/smda/ida/IdaInterface.py
+++ b/src/smda/ida/IdaInterface.py
@@ -32,14 +32,15 @@ class IdaInterface:
 
     def __init__(self):
         if not IdaInterface.instance:
-            if idaapi.IDA_SDK_VERSION < 740:
+            sdk_version = idaapi.IDA_SDK_VERSION
+            if not isinstance(sdk_version, int):
+                raise ValueError("Unsupported IDA SDK version")
+            if sdk_version < 740:
                 IdaInterface.instance = Ida73Interface()
-            elif idaapi.IDA_SDK_VERSION >= 740 and idaapi.IDA_SDK_VERSION < 850:
+            elif sdk_version < 850:
                 IdaInterface.instance = Ida74Interface()
-            elif idaapi.IDA_SDK_VERSION >= 850:
-                IdaInterface.instance = Ida85Interface()
             else:
-                raise ValueError("Unsupported IDA version")
+                IdaInterface.instance = Ida85Interface()
 
     def __getattr__(self, name):
         return getattr(self.instance, name)
@@ -122,7 +123,7 @@ class Ida74Interface(BackendInterface):
         if segment_starts:
             first_segment_start = segment_starts[0]
             # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start / 0x10000) * 0x10000
+            first_segment_start = (first_segment_start // 0x10000) * 0x10000
             base_addr = int(first_segment_start)
         return base_addr
 
@@ -233,9 +234,11 @@ class Ida73Interface(BackendInterface):
 
     def getBaseAddr(self):
         segment_starts = list(idautils.Segments())
+        if not segment_starts:
+            return 0
         first_segment_start = segment_starts[0]
         # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-        first_segment_start = (first_segment_start / 0x10000) * 0x10000
+        first_segment_start = (first_segment_start // 0x10000) * 0x10000
         return int(first_segment_start)
 
     def getBinary(self):
@@ -350,7 +353,7 @@ class Ida85Interface(BackendInterface):
         if segment_starts:
             first_segment_start = segment_starts[0]
             # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start / 0x10000) * 0x10000
+            first_segment_start = (first_segment_start // 0x10000) * 0x10000
             base_addr = int(first_segment_start)
         return base_addr
 

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -16,10 +16,10 @@ class FunctionCandidate:
         self.is_gap_candidate = False
         self.is_tailcall = False
         self.alignment = 0
-        if addr % 4 == 0:
-            self.alignment = 4
-        elif addr % 16 == 0:
+        if addr % 16 == 0:
             self.alignment = 16
+        elif addr % 4 == 0:
+            self.alignment = 4
         self.analysis_aborted = False
         self.abortion_reason = ""
         self._score = None
@@ -34,6 +34,8 @@ class FunctionCandidate:
         self._tfidf_score = tfidf_score
 
     def getTfIdf(self):
+        if self._tfidf_score is None:
+            return None
         return round(self._tfidf_score, 3)
 
     def getConfidence(self):

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -243,7 +243,7 @@ class FunctionCandidateManager:
                 byte = self.disassembly.getRawByte(gap_offset)
             except Exception as exc:
                 reraise_non_operational_exception(exc)
-                LOGGER.warn("could not fetch raw byte for gap pointer.")
+                LOGGER.warning("could not fetch raw byte for gap pointer.")
                 # print("0x%08x" % self.disassembly.binary_info.base_addr, "0x%08x" % self.disassembly.binary_info.binary_size, "0x%08x" % self.gap_pointer, "0x%08x" % gap_offset)
             # try to find padding symbols and skip them
             if isinstance(byte, int):
@@ -409,9 +409,9 @@ class FunctionCandidateManager:
             addr_block = self.disassembly.getRawBytes(offset + 2, 4)
             function_pointer = struct.unpack("i", addr_block)[0]
             # we need to calculate RIP + offset + 7 (48 ff 25 ** ** ** **)
-            if self.disassembly.getRawBytes(offset, 2) == "\xff\x25":
+            if self.disassembly.getRawBytes(offset, 2) == b"\xff\x25":
                 function_pointer += offset + 7
-            elif self.disassembly.getRawBytes(offset, 2) == "\xff\x15":
+            elif self.disassembly.getRawBytes(offset, 2) == b"\xff\x15":
                 function_pointer += offset + 6
             else:
                 raise Exception("resolvePointerReference: should only be used on call/jmp * ptr")

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -622,6 +622,6 @@ class IntelDisassembler:
                 candidate.getConfidence()
             self.disassembly.candidates[addr] = candidate
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
-        if cbAnalysisTimeout():
+        if cbAnalysisTimeout and cbAnalysisTimeout():
             self.disassembly.analysis_timeout = True
         return self.disassembly

--- a/src/smda/intel/IntelInstructionEscaper.py
+++ b/src/smda/intel/IntelInstructionEscaper.py
@@ -2047,7 +2047,6 @@ class IntelInstructionEscaper:
                 mnemonic,
             )
             return "U"
-        return mnemonic
 
     @staticmethod
     def escapeField(op_field, escape_registers=True, escape_pointers=True, escape_constants=True):

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -155,6 +155,9 @@ class JumpTableAnalyzer:
                         "Q",
                         self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
                     )[0]
+                else:
+                    LOGGER.warning("Unsupported bitness for jump table analysis: %s", bitness)
+                    break
                 if not self.disassembly.isAddrWithinMemoryImage(table_entry):
                     break
                 state.addDataRef(

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -142,22 +142,21 @@ class JumpTableAnalyzer:
         jumptable_size = jumptable_size if jumptable_size is not None else 0xFF
         jumptable_addresses = []
         bitness = self.disassembly.binary_info.bitness
-        entry_size = 4 if bitness == 32 else 8
+        if bitness == 32:
+            entry_size = 4
+            entry_format = "I"
+        elif bitness == 64:
+            entry_size = 8
+            entry_format = "Q"
+        else:
+            LOGGER.warning("Unsupported %s-bit jump table analysis", bitness)
+            return jumptable_addresses
         if self.disassembly.isAddrWithinMemoryImage(jumptable_address):
             for i in range(jumptable_size):
-                if bitness == 32:
-                    table_entry = struct.unpack(
-                        "I",
-                        self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
-                    )[0]
-                elif bitness == 64:
-                    table_entry = struct.unpack(
-                        "Q",
-                        self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
-                    )[0]
-                else:
-                    LOGGER.warning("Unsupported bitness for jump table analysis: %s", bitness)
-                    break
+                table_entry = struct.unpack(
+                    entry_format,
+                    self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
+                )[0]
                 if not self.disassembly.isAddrWithinMemoryImage(table_entry):
                     break
                 state.addDataRef(

--- a/src/smda/intel/LanguageAnalyzer.py
+++ b/src/smda/intel/LanguageAnalyzer.py
@@ -21,13 +21,12 @@ class LanguageAnalyzer:
         self.strings = None
 
     def validPEHeader(self):
-        is_pe = True
-        is_pe |= self.disassembly.binary_info.binary[0:2] == "\x4d\x5a"
+        is_pe = self.disassembly.binary_info.binary[0:2] == b"\x4d\x5a"
         if len(self.disassembly.binary_info.binary) > 0x40:
             pe_offset = struct.unpack("I", self.disassembly.binary_info.binary[0x3C:0x40])[0]
-            is_pe |= (
+            is_pe = is_pe and (
                 len(self.disassembly.binary_info.binary) > pe_offset
-                and self.disassembly.binary_info.binary[pe_offset : pe_offset + 2] == "\x50\x45"
+                and self.disassembly.binary_info.binary[pe_offset : pe_offset + 2] == b"\x50\x45"
             )
         else:
             is_pe = False
@@ -54,14 +53,14 @@ class LanguageAnalyzer:
     def getVisualBasicScore(self):
         # check for the typical import of msvbvm60.dll
         vb_score = 0.0
-        if "MSVBVM60.DLL" in self.getStrings():
+        if b"MSVBVM60.DLL" in self.getStrings():
             vb_score = 0.5
         return vb_score
 
     def getDotNetScore(self):
         dot_net_score = 0.0
         # check for the typical import of mscorelib.dll and mscoree.dll
-        if "mscorelib.dll" in self.getStrings() or "mscoree.dll" in self.getStrings():
+        if b"mscorelib.dll" in self.getStrings() or b"mscoree.dll" in self.getStrings():
             dot_net_score = 0.35
         # check for a functioning PE-Header and typical meta-data
         if self.validPEHeader():
@@ -73,7 +72,7 @@ class LanguageAnalyzer:
                 start_addr = struct.unpack("<I", match.group("start"))[0]
                 if start_addr == 0x2000:
                     dot_net_score = max(dot_net_score, 0.8)
-                if self.disassembly.getRawBytes(start_addr, 4) == "\xdb\x4d\x00\x79":
+                if self.disassembly.getRawBytes(start_addr, 4) == b"\xdb\x4d\x00\x79":
                     dot_net_score = max(dot_net_score, 0.9)
         return dot_net_score
 
@@ -83,7 +82,7 @@ class LanguageAnalyzer:
     def getDelphiScore(self):
         delphi_score = 0.0
         # Check if Delphi-Locales are present in strings
-        if "Borland\\locales" in self.getStrings():
+        if b"Borland\\locales" in self.getStrings():
             delphi_score = max(delphi_score, 0.5)
         if self._getPETimestamp() == 0x2A425E19:
             delphi_score = 0.5

--- a/src/smda/intel/MnemonicTfIdf.py
+++ b/src/smda/intel/MnemonicTfIdf.py
@@ -438,6 +438,8 @@ class MnemonicTfIdf:
         return self.tfidf(term_counts)
 
     def tfidf(self, term_counts):
+        if not term_counts:
+            return 0.0
         score = 0
         sum_term_counts = sum(term_counts.values())
         max_count = max(term_counts.values())

--- a/src/smda/utility/BracketQueue.py
+++ b/src/smda/utility/BracketQueue.py
@@ -1,6 +1,6 @@
 class BracketQueue:
     """
-    This queue is tailored based on our research rsults regarding function entry point identification
+    This queue is tailored based on our research results regarding function entry point identification
     """
 
     def __init__(self, candidates=None, initial_brackets=None):

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -22,8 +22,7 @@ def has_bogus_sections(elffile, base_addr=0):
     for section in elffile.sections:
         if section.virtual_address:
             max_virtual_address = max(max_virtual_address, section.size + section.virtual_address)
-    if (max_virtual_address - base_addr) > sys.maxsize:
-        return True
+    return (max_virtual_address - base_addr) > sys.maxsize
 
 
 class ElfFileLoader:
@@ -79,7 +78,7 @@ class ElfFileLoader:
                 min_virtual_address = min(min_virtual_address, section.virtual_address)
                 min_raw_offset = min(min_raw_offset, section.file_offset)
         else:
-            LOGGER.warn("ELF: found possibly bogus section information, trying to parse segments.")
+            LOGGER.warning("ELF: found possibly bogus section information, trying to parse segments.")
         # parse segments regardless
         for segment in elffile.segments:
             if not segment.virtual_address:
@@ -116,15 +115,15 @@ class ElfFileLoader:
                 segment.virtual_address,
             )
             if len(segment.content) != segment.physical_size:
-                LOGGER.warn("ELF: Mismatch in segment content vs. header-specified physical size!")
+                LOGGER.warning("ELF: Mismatch in segment content vs. header-specified physical size!")
                 if len(segment.content) < segment.physical_size:
-                    LOGGER.warn("ELF: Padding to physical size with zeroes!")
+                    LOGGER.warning("ELF: Padding to physical size with zeroes!")
                     mapped_binary[rva : rva + len(segment.content)] = segment.content
                     mapped_binary[rva + len(segment.content) : rva + segment.physical_size] = b"\x00" * (
                         segment.physical_size - len(segment.content)
                     )
                 else:
-                    LOGGER.warn("ELF: More content than physical size!? Aborting, please report this case. :)")
+                    LOGGER.warning("ELF: More content than physical size!? Aborting, please report this case. :)")
                     raise AssertionError("Received more content than physical size, which should never be possible?")
             else:
                 mapped_binary[rva : rva + segment.physical_size] = segment.content
@@ -258,6 +257,8 @@ class ElfFileLoader:
     def getCodeAreas(binary):
         # TODO add machine types whenever we add more architectures
         elffile = lief.parse(binary)
+        if elffile is None:
+            return []
         code_areas = []
         for section in elffile.sections:
             section_flags = 0

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -16,12 +16,13 @@ class FileLoader:
     _bitness = 0
     _abi = ""
     _architecture = ""
-    _code_areas = []
+    _code_areas = None
     file_loaders = [PeFileLoader, ElfFileLoader, MachoFileLoader, DelphiKbFileLoader, DexFileLoader]
 
     def __init__(self, file_path, load_file=True, map_file=False):
         self._file_path = file_path
         self._map_file = map_file
+        self._code_areas = []
         if load_file:
             self._loadFile()
 

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -124,7 +124,10 @@ class MachoFileLoader:
                 rva + segment.file_size,
                 segment.virtual_address,
             )
-            assert len(segment.content) == segment.file_size
+            if len(segment.content) != segment.file_size:
+                raise ValueError(
+                    f"Segment content size mismatch: expected {segment.file_size}, got {len(segment.content)}"
+                )
             mapped_binary[rva : rva + segment.file_size] = segment.content
 
         # map sections.

--- a/src/smda/utility/PriorityQueue.py
+++ b/src/smda/utility/PriorityQueue.py
@@ -1,11 +1,19 @@
 import heapq
 
 
+class _MaxHeapItem:
+    def __init__(self, element):
+        self.element = element
+
+    def __lt__(self, other):
+        return other.element < self.element
+
+
 class PriorityQueue:
     def __init__(self, content=None):
         if content is None:
             content = []
-        self.heap = content
+        self.heap = [_MaxHeapItem(element) for element in content]
         if self.heap:
             self.update()
 
@@ -18,21 +26,13 @@ class PriorityQueue:
     def next(self):
         if not self.heap:
             raise StopIteration
-        if len(self.heap) == 1:
-            return self.heap.pop()
-        last_item = self.heap.pop()
-        result = self.heap[0]
-        self.heap[0] = last_item
-        heapq._siftup_max(self.heap, 0)
-        return result
+        return heapq.heappop(self.heap).element
 
     def add(self, element):
-        self.heap.append(element)
-        heapq._siftdown_max(self.heap, 0, len(self.heap) - 1)
+        heapq.heappush(self.heap, _MaxHeapItem(element))
 
     def update(self, target_candidate=None):
-        if target_candidate is None:
-            heapq._heapify_max(self.heap)
+        heapq.heapify(self.heap)
 
     def __str__(self):
-        return str(self.heap)
+        return str([item.element for item in self.heap])

--- a/tests/testBracketQueue.py
+++ b/tests/testBracketQueue.py
@@ -6,6 +6,7 @@ import unittest
 from smda.common.BinaryInfo import BinaryInfo
 from smda.intel.FunctionCandidate import FunctionCandidate
 from smda.utility.BracketQueue import BracketQueue
+from smda.utility.PriorityQueue import PriorityQueue
 
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
@@ -215,6 +216,19 @@ class BracketQueueTestSuite(unittest.TestCase):
         queue.ensure_order()
         for _index, candidate in enumerate(queue):
             print(candidate)
+
+    def test_priority_queue_uses_public_heap_ordering(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        low = FunctionCandidate(binary_info, 0x20)
+        high = FunctionCandidate(binary_info, 0x10)
+        high.addCallRef(0x100)
+
+        queue = PriorityQueue([low, high])
+
+        self.assertIs(next(queue), high)
+        self.assertIs(next(queue), low)
 
 
 if __name__ == "__main__":

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -1,0 +1,31 @@
+import hashlib
+import struct
+import unittest
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
+from smda.common.SmdaFunction import SmdaFunction
+
+
+class TestCommonModels(unittest.TestCase):
+    def test_empty_basic_block_string_is_safe(self):
+        self.assertEqual(str(SmdaBasicBlock([])), "0x????????: (   0)")
+
+    def test_function_hash_helpers_use_little_endian(self):
+        function = SmdaFunction()
+        function.pic_hash = 0x0102030405060708
+        function.getPicHashSequence = lambda binary_info: b"pic-sequence"
+        function.getOpcHashSequence = lambda: b"opc-sequence"
+
+        self.assertEqual(function.getPicHashAsHex(), struct.pack("<Q", function.pic_hash).hex())
+        self.assertEqual(
+            function.getPicHash(None),
+            struct.unpack("<Q", hashlib.sha256(b"pic-sequence").digest()[:8])[0],
+        )
+        self.assertEqual(
+            function.getOpcHash(),
+            struct.unpack("<Q", hashlib.sha256(b"opc-sequence").digest()[:8])[0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -394,16 +394,11 @@ class DalvikDisassemblerTestSuite(unittest.TestCase):
         self.assertEqual(report.bitness, 32)
         self.assertGreater(report.num_functions, 2000)
 
-    def testDisassembleBufferIntelOnDexAutodetectsDalvik(self):
-        # Pinning the contract: an explicit architecture="intel" on DEX bytes
-        # is overridden by magic-byte autodetection rather than producing
-        # garbage Intel disassembly. If the autodetect ever becomes opt-in,
-        # this test must be updated to assert error/empty Intel output instead.
+    def testDisassembleBufferExplicitIntelBackendPreservedForDexBytes(self):
         intel_disasm = Disassembler(config, backend="intel")
         report = intel_disasm.disassembleBuffer(self.dex_binary, base_addr=0, architecture="intel")
-        self.assertEqual(report.architecture, "dalvik")
+        self.assertEqual(report.architecture, "intel")
         self.assertEqual(report.bitness, 32)
-        self.assertGreater(report.num_functions, 2000)
 
     def testAnalyzeScriptRawDexAvoidsBaseAddrAndOepWarnings(self):
         result = subprocess.run(

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -3,11 +3,19 @@
 import logging
 import os
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import lief
 
+from smda.cil.CilDisassembler import CilDisassembler
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.labelprovider.ElfApiResolver import ElfApiResolver
+from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
+from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
 from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
 from smda.utility.FileLoader import FileLoader
 
 from .context import config
@@ -136,6 +144,65 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         disasm._disassemble(binary_info)
         komplex_unmapped_disassembly = disasm.disassembleUnmappedBuffer(komplex_binary)
         self.assertEqual(komplex_unmapped_disassembly.num_functions, 211)
+
+    def test_binary_info_and_file_loader_do_not_share_code_areas(self):
+        first_binary = BinaryInfo(b"a")
+        second_binary = BinaryInfo(b"b")
+        first_binary.code_areas.append([1, 2])
+
+        first_loader = FileLoader("/", load_file=False)
+        second_loader = FileLoader("/", load_file=False)
+        first_loader.getCodeAreas().append([3, 4])
+
+        self.assertEqual(second_binary.code_areas, [])
+        self.assertEqual(second_loader.getCodeAreas(), [])
+
+    def test_pe_symbol_provider_returns_empty_mapping_without_code_section(self):
+        symbol_provider = PeSymbolProvider(None)
+        lief_binary = SimpleNamespace(sections=[], symbols=[])
+
+        self.assertEqual(symbol_provider.parseSymbols(lief_binary), {})
+
+    def test_go_pclntab_offset_returns_numeric_zero(self):
+        provider = GoSymbolProvider(None)
+        pclntab = b"\x00\xff\xff\xff\x00\x00\x01\x04"
+
+        self.assertEqual(provider.getPcLntabOffset(pclntab), 0)
+
+    def test_cil_disassembler_accepts_missing_timeout_callback(self):
+        binary_info = BinaryInfo(b"MZ")
+        fake_pe = SimpleNamespace(net=SimpleNamespace(mdtables=SimpleNamespace(MethodDef=[])))
+
+        with mock.patch("smda.cil.CilDisassembler.dnfile.dnPE", return_value=fake_pe):
+            result = CilDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertFalse(result.analysis_timeout)
+
+    def test_cil_jmp_records_edge_without_aborting_function_analysis(self):
+        class FakeInstruction:
+            offset = 0x1000
+            opcode = "jmp"
+            operand = object()
+
+            def get_bytes(self):
+                return b"\x27\x00"
+
+        disassembler = CilDisassembler(SmdaConfig())
+        disassembler.disassembly = DisassemblyResult()
+        method_body = SimpleNamespace(offset=0x1000, instructions=[FakeInstruction()])
+
+        with mock.patch("smda.cil.CilDisassembler.format_operand", return_value="0x2000"):
+            state = disassembler.analyzeFunction(None, method_body.offset, method_body)
+
+        self.assertEqual(state.code_refs_from[0x1000], {0x2000})
+        self.assertIn(0x1000, disassembler.disassembly.functions)
+
+    def test_elf_api_resolver_uses_relocation_slot_address(self):
+        resolver = ElfApiResolver(None)
+        resolver._api_map["lief"][0x4018] = ("GLIBC_2.2.5", "puts")
+
+        self.assertEqual(resolver.getApi(0x4018, absolute_addr=0x1000), ("GLIBC_2.2.5", "puts"))
+        self.assertEqual(resolver.getApi(0x1000, absolute_addr=0x4018), (None, None))
 
 
 if __name__ == "__main__":

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -10,6 +10,7 @@ import lief
 
 from smda.cil.CilDisassembler import CilDisassembler
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.labelprovider.CilSymbolProvider import CilSymbolProvider
 from smda.common.labelprovider.ElfApiResolver import ElfApiResolver
 from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
 from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
@@ -203,6 +204,18 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
 
         self.assertEqual(resolver.getApi(0x4018, absolute_addr=0x1000), ("GLIBC_2.2.5", "puts"))
         self.assertEqual(resolver.getApi(0x1000, absolute_addr=0x4018), (None, None))
+
+    def test_cil_symbol_provider_clears_symbols_before_parse(self):
+        provider = CilSymbolProvider(None)
+        provider._addr_to_func_symbols[0x1000] = "stale"
+        provider._func_symbol_to_addr["stale"] = 0x1000
+        binary_info = BinaryInfo(b"not a dotnet file")
+
+        with mock.patch("smda.common.labelprovider.CilSymbolProvider.dnfile.dnPE", side_effect=ValueError("bad pe")):
+            provider.update(binary_info)
+
+        self.assertEqual(provider.getFunctionSymbols(), {})
+        self.assertIsNone(provider.getAddress("stale"))
 
 
 if __name__ == "__main__":

--- a/tests/testIntegration.py
+++ b/tests/testIntegration.py
@@ -5,9 +5,11 @@ import os
 import unittest
 
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 from smda.common.SmdaFunction import SmdaFunction
 from smda.common.SmdaReport import SmdaReport
 from smda.Disassembler import Disassembler
+from smda.DisassemblyStatistics import DisassemblyStatistics
 from smda.utility.FileLoader import FileLoader
 
 from .context import config
@@ -145,6 +147,48 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         found_block = self.asprox_disassembly.findBlockByContainedAddress(0xFFFFFF00)
         assert found_function is None
         assert found_block is None
+
+    def test_smda_basic_block_from_dict_initializes_fields(self):
+        block = SmdaBasicBlock.fromDict([[0x401000, "90", "nop", ""]])
+
+        self.assertEqual(block.offset, 0x401000)
+        self.assertEqual(block.length, 1)
+        self.assertEqual(block.toDict(), [[0x401000, "90", "nop", ""]])
+        self.assertEqual(list(SmdaBasicBlock([]).getInstructions()), [])
+
+    def test_statistics_add_is_pure_and_iadd_mutates(self):
+        left = DisassemblyStatistics.fromDict(
+            {
+                "num_functions": 1,
+                "num_recursive_functions": 2,
+                "num_leaf_functions": 3,
+                "num_basic_blocks": 4,
+                "num_instructions": 5,
+                "num_api_calls": 6,
+                "num_function_calls": 7,
+                "num_failed_functions": 8,
+                "num_failed_instructions": 9,
+            }
+        )
+        right = DisassemblyStatistics.fromDict(
+            {
+                "num_functions": 10,
+                "num_recursive_functions": 20,
+                "num_leaf_functions": 30,
+                "num_basic_blocks": 40,
+                "num_instructions": 50,
+                "num_api_calls": 60,
+                "num_function_calls": 70,
+                "num_failed_functions": 80,
+                "num_failed_instructions": 90,
+            }
+        )
+
+        total = left + right
+        self.assertEqual(left.num_functions, 1)
+        self.assertEqual(total.num_functions, 11)
+        left += right
+        self.assertEqual(left.num_failed_instructions, 99)
 
 
 if __name__ == "__main__":

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -1,6 +1,12 @@
 import unittest
+from types import SimpleNamespace
 
+from smda.common.BinaryInfo import BinaryInfo
+from smda.intel.FunctionCandidate import FunctionCandidate
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.intel.IntelDisassembler import IntelDisassembler
+from smda.intel.MnemonicTfIdf import MnemonicTfIdf
+from smda.SmdaConfig import SmdaConfig
 
 
 class DummyProvider:
@@ -66,6 +72,39 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertEqual(disassembler.resolveApi(0x401000, 0x500000), ("kernel32.dll", "CreateFileA"))
         self.assertEqual(disassembler.resolveSymbol(0x401100), "handler")
         self.assertEqual(set(disassembler.getSymbolCandidates()), {0x401000, 0x401100})
+
+    def test_function_candidate_alignment_and_empty_tfidf_are_safe(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+
+        candidate = FunctionCandidate(binary_info, 0x10)
+
+        self.assertEqual(candidate.alignment, 16)
+        self.assertIsNone(candidate.getTfIdf())
+
+    def test_mnemonic_tfidf_empty_counts_returns_zero(self):
+        self.assertEqual(MnemonicTfIdf().tfidf({}), 0.0)
+
+    def test_pointer_reference_uses_byte_prefixes(self):
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.bitness = 64
+        manager.disassembly = SimpleNamespace(
+            binary_info=SimpleNamespace(base_addr=0x1000),
+            getRawBytes=lambda offset, size: b"\xff\x25" if size == 2 else (1).to_bytes(4, "little", signed=True),
+        )
+
+        self.assertEqual(manager.resolvePointerReference(0x20), 0x1028)
+
+    def test_accepts_missing_timeout_callback(self):
+        binary_info = BinaryInfo(b"\x90\xc3")
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertFalse(result.analysis_timeout)
 
 
 if __name__ == "__main__":

--- a/tests/testLanguageAnalyzer.py
+++ b/tests/testLanguageAnalyzer.py
@@ -35,6 +35,18 @@ class TestLanguageAnalyzer(unittest.TestCase):
         self.assertEqual(len({call[0] for call in findall_calls}), 2)
         self.assertTrue(all(call[1] == binary for call in findall_calls))
 
+    def test_uses_bytes_for_pe_and_language_markers(self):
+        binary = bytearray(b"MZ" + b"\x00" * 0x100)
+        binary[0x3C:0x40] = (0x80).to_bytes(4, "little")
+        binary[0x80:0x82] = b"PE"
+        binary.extend(b"MSVBVM60.DLL\x00mscorelib.dll\x00Borland\\locales\x00")
+        analyzer = LanguageAnalyzer(_DummyDisassembly(bytes(binary)))
+
+        self.assertTrue(analyzer.validPEHeader())
+        self.assertEqual(analyzer.getVisualBasicScore(), 0.5)
+        self.assertGreaterEqual(analyzer.getDotNetScore(), 0.35)
+        self.assertEqual(analyzer.getDelphiScore(), 0.5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -1,14 +1,17 @@
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
 
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.labelprovider.ElfSymbolProvider import ElfSymbolProvider
 from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
 from smda.common.labelprovider.rust_demangler import demangle
 from smda.common.labelprovider.rust_demangler.rust import TypeNotFoundError
+from smda.common.labelprovider.rust_demangler.rust_legacy import LegacyDemangler, UnableToLegacyDemangle
 from smda.common.labelprovider.rust_demangler.rust_v0 import (
     Printer,
     UnableTov0Demangle,
+    V0Demangler,
 )
 from smda.common.labelprovider.rust_demangler.utils import remove_bad_spaces
 from smda.common.labelprovider.RustSymbolProvider import RustSymbolProvider
@@ -150,6 +153,38 @@ class TestRustDemangler(unittest.TestCase):
             results = list(executor.map(demangle, symbols * 5))
 
         self.assertEqual(results, expected * 5)
+
+    def test_malformed_inputs_raise_demangle_errors(self):
+        """Malformed Rust symbols should use demangler error types."""
+
+        with self.assertRaises(UnableToLegacyDemangle):
+            LegacyDemangler().demangle("_Z3fooE")
+        with self.assertRaises(UnableToLegacyDemangle):
+            LegacyDemangler().demangle("_ZN3$u$E")
+        with self.assertRaises(UnableTov0Demangle):
+            V0Demangler().demangle("_NvC3foo")
+        with self.assertRaises(UnableTov0Demangle):
+            V0Demangler().demangle("_RNvC3fooKc110000")
+
+    def test_v0_backref_path_updates_parent_printer_output(self):
+        """Backref path printers should copy string output back to the caller."""
+
+        class FakeParser:
+            def eat(self, token):
+                return token == "B"
+
+        class FakeBackrefPrinter:
+            out = "prefix::Backref"
+
+            def print_path_maybe_open_generics(self):
+                return True
+
+        printer = Printer(FakeParser(), "prefix::", bound=0)
+
+        with mock.patch.object(printer, "backref_printer", return_value=FakeBackrefPrinter()):
+            self.assertTrue(printer.print_path_maybe_open_generics())
+
+        self.assertEqual(printer.out, "prefix::Backref")
 
 
 class TestRustSymbolProvider(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR addresses the CodeRabbit CLI findings as a single reviewer-friendly hardening pass. The changes focus on runtime safety, API-contract correctness, parser/provider guardrails, and cleanup of fragile patterns that could produce crashes or misleading behavior on malformed or edge-case inputs.

The branch is intentionally rebased onto `master` and contains one commit so reviewers can inspect the CodeRabbit follow-up independently from the existing clawpatch/Dalvik PR.

## Why

The CodeRabbit audit flagged a broad set of small but real correctness risks across SMDA:

- optional timeout callbacks could be called when unset
- byte-oriented binary analysis compared bytes to text strings in several paths
- parser and label-provider helpers returned the wrong shape or failed on missing parse objects
- DTO-style objects had unsafe construction or shared mutable defaults
- demanglers leaked raw parser exceptions for malformed Rust symbols
- utility code relied on private heap helpers, runtime `assert`, direct prints, or deprecated logger APIs
- explicit backend selection could be overridden by DEX autodetection

These are mostly narrow fixes, but together they reduce crash surface and make malformed binary handling more predictable.

## What Changed

### Runtime and backend safety

- Guarded optional timeout callbacks in Intel and CIL analysis.
- Preserved explicit backend selection so DEX autodetection does not override `backend="intel"`.
- Fixed function-candidate alignment ordering and made empty TF-IDF inputs safe.
- Added an explicit unsupported-bitness guard in jump-table analysis.
- Cleaned unreachable CIL debug print code.
- Kept CIL `jmp` handling non-fatal by recording the edge, ending fallthrough, and logging the unsupported instruction.

### Binary parsing and provider contracts

- Made PE/ELF/Mach-O/file-loader paths safer on missing or malformed parse results.
- Corrected PE, ELF, Go, PDB, Delphi, and WinAPI provider behavior around empty inputs, missing objects, and provider API contracts.
- Ensured provider methods return stable empty mappings or tuples instead of `None` where callers expect structured values.
- Kept ELF API lookup keyed by relocation slot address while preserving the shared provider signature.

### Bytes/string correctness

- Normalized PE header and language-marker checks to bytes-aware comparisons.
- Fixed 64-bit pointer-reference opcode matching to compare byte prefixes consistently.

### DTO, statistics, and utility cleanup

- Made `DisassemblyStatistics.__add__` pure and kept in-place mutation in `__iadd__`.
- Made `SmdaBasicBlock.fromDict()` and instruction iteration safe for empty or deserialized blocks.
- Initialized per-instance mutable defaults for binary metadata and file-loader code areas.
- Replaced private heapq helper usage in `PriorityQueue` with public heap APIs.
- Replaced direct library prints and deprecated logger calls with logger usage.
- Replaced Mach-O runtime `assert` validation with an explicit exception.

### Rust demangler hardening

- Validated malformed legacy escape parsing before slicing.
- Converted malformed legacy and v0 demangler inputs to demangler-specific error paths.
- Added recursion cleanup/guarding for v0 printing paths.
- Preserved original input for `.llvm.` error reporting.
- Copied v0 backref printer output back to the parent printer so immutable string updates are not lost.

### Tests

- Moved the temporary CodeRabbit regression tests into the existing subsystem suites.
- No `testCodeRabbitFindings.py` or CodeRabbit-specific test module remains.
- Added focused coverage for timeout callbacks, bytes/string analysis, pointer opcode matching, mutable defaults, pure statistics addition, parser/provider safe defaults, priority queue ordering, explicit backend preservation, non-fatal CIL `jmp`, ELF relocation-slot API lookup, Rust v0 backref output propagation, and malformed Rust demangler inputs.

## Review Notes

- The subagent pattern scan confirmed no CodeRabbit-named tests remain and no local tooling or fixture files are included.
- The scan also flagged the explicit DEX/backend behavior as substantive; that change is intentional because it addresses the finding that explicit backend selection could still be overridden by DEX autodetection.
- Follow-up review comments were addressed where they represented real runtime regressions: CIL `jmp`, Rust v0 backref output, and ELF API lookup keying.
- The escaper `return mnemonic` comments were reviewed and left unchanged because the removed returns were unreachable after an `else` branch that already returns `"U"`; the existing escaper tests still pass.
- The branch contains one commit over `master` for efficient review.

## Validation

- `python -m pytest tests/testDalvikDisassembler.py tests/testEscaper.py tests/testRustSymbolProvider.py tests/testFileFormatParsers.py tests/testIntelDisassembler.py tests/testIndirectCallAnalyzer.py -q` -> 73 passed
- `make test` -> 106 passed
- `make lint` -> all checks passed
- `python -m ruff check src/smda tests/testDalvikDisassembler.py` -> all checks passed
- `git diff --check` -> passed

## Risk

The changes are intentionally narrow, but they touch multiple parser/provider and backend paths. The main residual risk is format-specific behavior for unusual binaries not covered by fixtures. The added tests target the reported crash and contract shapes, and the full existing test suite passes on the rebased branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved DEX auto-detection logic respects explicitly specified backends during analysis.
  * Enhanced Go binary string extraction support.

* **Bug Fixes**
  * Fixed analysis timeout callback handling.
  * Improved robustness when analyzing CIL binaries and handling edge cases.
  * Fixed address resolution in jump table analysis for 64-bit binaries.
  * Enhanced code area isolation across instances.

* **Improvements**
  * Standardized API resolver interface across format providers.
  * Better error diagnostics and logging for debugging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/r0ny123/smda/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->