### PR TITLE
perf(core): cut per-call overhead in candidate scoring and hash sequences

### DIFF
--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -59,7 +59,7 @@ class SmdaBasicBlock:
                         + self.smda_function.smda_report.binary_size,
                     )
                 )
-            return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+            return "".join(escaped_binary_seqs).encode("ascii")
 
     def getOpcBlockHash(self):
         if self.opcblockhash is not None:
@@ -76,7 +76,7 @@ class SmdaBasicBlock:
             escaped_binary_seqs = []
             for instruction in self.getInstructions():
                 escaped_binary_seqs.append(instruction.getEscapedToOpcodeOnly(self.smda_function._escaper))
-            return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+            return "".join(escaped_binary_seqs).encode("ascii")
 
     def getPredecessors(self):
         predecessors = []

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -200,7 +200,7 @@ class SmdaFunction:
                         upper_addr=binary_info.base_addr + binary_info.binary_size,
                     )
                 )
-        return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+        return "".join(escaped_binary_seqs).encode("ascii")
 
     def getOpcHash(self):
         return struct.unpack("<Q", hashlib.sha256(self.getOpcHashSequence()).digest()[:8])[0]
@@ -210,7 +210,7 @@ class SmdaFunction:
         for _, block in sorted(self.blocks.items()):
             for instruction in block:
                 escaped_binary_seqs.append(instruction.getEscapedToOpcodeOnly(self._escaper))
-        return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+        return "".join(escaped_binary_seqs).encode("ascii")
 
     def _parseBlocks(self, block_dict):
         self.blocks = {}

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -2,6 +2,10 @@ from binascii import hexlify
 
 from .definitions import COMMON_PROLOGUES
 
+# Hoisted: prologue lengths are checked longest-first on every candidate scoring call.
+# Pre-sort once at import time instead of re-sorting per call (hot path during CFG recovery).
+_COMMON_PROLOGUE_LENGTHS = sorted((int(k) for k in COMMON_PROLOGUES), reverse=True)
+
 
 class FunctionCandidate:
     def __init__(self, binary_info, addr):
@@ -10,7 +14,9 @@ class FunctionCandidate:
         rel_start_addr = addr - binary_info.base_addr
         self.bytes = binary_info.binary[rel_start_addr : rel_start_addr + 5]
         self.lang_spec = None
-        self.call_ref_sources = []
+        # set, not list: addCallRef / removeCallRefs do membership tests in the inner
+        # CFG-recovery loop. Order is never read externally (only len + truthiness).
+        self.call_ref_sources = set()
         self.finished = False
         self.is_symbol = False
         self.is_gap_candidate = False
@@ -61,7 +67,7 @@ class FunctionCandidate:
         return self._confidence
 
     def hasCommonFunctionStart(self):
-        for length in sorted([int(length_str) for length_str in COMMON_PROLOGUES], reverse=True):
+        for length in _COMMON_PROLOGUE_LENGTHS:
             byte_sequence = self.bytes[:length]
             if byte_sequence in COMMON_PROLOGUES[f"{length}"][self.bitness]:
                 return True
@@ -69,7 +75,7 @@ class FunctionCandidate:
 
     def getFunctionStartScore(self):
         if self.function_start_score is None:
-            for length in sorted([int(length_str) for length_str in COMMON_PROLOGUES], reverse=True):
+            for length in _COMMON_PROLOGUE_LENGTHS:
                 byte_sequence = self.bytes[:length]
                 if byte_sequence in COMMON_PROLOGUES[f"{length}"][self.bitness]:
                     self.function_start_score = COMMON_PROLOGUES[f"{length}"][self.bitness][byte_sequence]
@@ -78,14 +84,12 @@ class FunctionCandidate:
         return self.function_start_score
 
     def addCallRef(self, source_addr):
-        if source_addr not in self.call_ref_sources:
-            self.call_ref_sources.append(source_addr)
+        self.call_ref_sources.add(source_addr)
         self._score = None
 
     def removeCallRefs(self, source_addrs):
         for addr in source_addrs:
-            if addr in self.call_ref_sources:
-                self.call_ref_sources.remove(addr)
+            self.call_ref_sources.discard(addr)
         self._score = None
 
     def setIsTailcallCandidate(self, is_tailcall):
@@ -179,11 +183,10 @@ class FunctionCandidate:
     def __str__(self):
         characteristics = self.getCharacteristics()
         prologue_score = f"{self.getFunctionStartScore()}"
-        ref_summary = (
-            f"{len(self.call_ref_sources)}"
-            if len(self.call_ref_sources) != 1
-            else f"{len(self.call_ref_sources)}: 0x{self.call_ref_sources[0]:x}"
-        )
+        if len(self.call_ref_sources) == 1:
+            ref_summary = f"1: 0x{next(iter(self.call_ref_sources)):x}"
+        else:
+            ref_summary = f"{len(self.call_ref_sources)}"
         return f"0x{self.addr:x}: {hexlify(self.bytes)} -> {prologue_score} (total score: {self.getScore()}), inref: {ref_summary} | {characteristics}"
 
     def toJson(self):

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -88,8 +88,7 @@ class FunctionCandidate:
         self._score = None
 
     def removeCallRefs(self, source_addrs):
-        for addr in source_addrs:
-            self.call_ref_sources.discard(addr)
+        self.call_ref_sources.difference_update(source_addrs)
         self._score = None
 
     def setIsTailcallCandidate(self, is_tailcall):


### PR DESCRIPTION
## Summary

Three related, behavior-preserving hot-path tweaks. Single optimization class: **avoidable per-call Python overhead in Intel candidate scoring and PIC/OPC hash sequence assembly.**

### 1. PIC/OPC hash byte conversion (`SmdaFunction`, `SmdaBasicBlock`)

Replace `bytes([ord(c) for c in "".join(seqs)])` with `"".join(seqs).encode("ascii")` in the four hash-sequence helpers (`getPicHashSequence`, `getOpcHashSequence`, `getPicBlockHashSequence`, `getOpcBlockHashSequence`).

The escaper only emits ASCII (hex chars + `?`), so the encoded bytes are bit-identical. The per-character Python loop is gone.

### 2. Hoist sorted prologue lengths (`FunctionCandidate`)

`sorted([int(length_str) for length_str in COMMON_PROLOGUES], reverse=True)` was rebuilt on every call to `hasCommonFunctionStart` / `getFunctionStartScore`. Both are reached from `calculateScore`, `getCharacteristics`, `__str__`, and `toJson`, so every candidate touched the list many times. Lifted to module-level `_COMMON_PROLOGUE_LENGTHS`.

### 3. `call_ref_sources` list → set (`FunctionCandidate`)

The inner CFG-recovery loop does `addr not in call_ref_sources` on every call instruction; with a list that's O(n) per call and quadratic for hot targets (popular runtime stubs accumulate many sources). Set makes add/discard/membership O(1). Verified no external order dependence (`grep` across `src/` and `tests/`): only `len()` and truthiness are used externally. The single `[0]` read was inside `__str__`'s `len == 1` branch and is now `next(iter(...))`.

## Measurements (focused bench, asprox fixture, Python 3.11.15)

| Path | Before | After | Δ |
|---|---|---|---|
| `calculateScore × 200_000` | 322.2 ms | 179.9 ms | **−44%** |
| `getPicBlockHashSequence × 2140 blocks` | 36.3 ms | 31.1 ms | −14% |
| `getOpcHashSequence × 105 funcs` | 47.3 ms | 43.7 ms | −8% |
| `getOpcBlockHashSequence × 2140 blocks` | 50.3 ms | 47.6 ms | −5% |
| `getPicHashSequence × 105 funcs` | 31.0 ms | 30.1 ms | −3% |
| `disassembleBuffer` (e2e, asprox) | 1617 ms | 1579 ms | −2.4% |

Microbench on a representative 3.7 KB escaped sequence: `bytes([ord(c) for c in s])` vs `s.encode("ascii")` is ~600x slower per call — the e2e gain looks small because Capstone/escaper work dominates a single call, but the cost scales linearly with function/block count, so larger binaries see proportionally larger absolute savings.

## Behavior compatibility

- `pic_hash`, `opc_hash`, and serialized report `sha256` unchanged on asprox.
- Public report schema unchanged.
- All 90 tests + 43 subtests pass.
- `make lint` (ruff check + format check) clean.

## Test plan

- [x] `python -m pytest tests/test*` — 90 passed, 43 subtests passed in 13.56 s
- [x] `python -m ruff check .` — All checks passed
- [x] `python -m ruff format --check .` — 94 files already formatted
- [x] Before/after benchmark on asprox fixture (numbers above)
- [x] Verified report serialization assertions in `testIntegration.testAsproxMarshalling` / `testCutwailMarshalling` still hold

## Residual perf risk

None expected. Set iteration order isn't insertion order, but no caller reads `call_ref_sources` in an order-dependent way. The only read of an element by index was the `__str__` single-element case, which by definition has one element.

## Out of scope for this branch (noted during the sweep, deferred)

- `IndirectCallAnalyzer.searchBlock` is O(blocks × instructions) inside a 3-deep recursion — a one-shot `addr → block` index would help, but is more invasive.
- `SmdaFunction.getNormalizedBlockRefs` is recomputed unconditionally; safe caching requires tracking `architecture_metadata` mutation.
- `BinaryInfo.getImportedFunctions` calls `PeSymbolProvider(None).parseSymbols(lief_result)` and discards the result before re-instantiating for `parseImports` — looks like wasted work but warrants a separate audit of provider side effects.
- Loaders re-`lief.parse()` the same buffer across `getArchitecture` / `getCodeAreas` calls. `BinaryInfo` already caches, but the static `*FileLoader` accessors do not.

https://claude.ai/code/session_01C8CcS2k1g59ByLKYdEcaxR

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8CcS2k1g59ByLKYdEcaxR)_