### PR TITLE
perf(intel): index-backed searchBlock in IndirectCallAnalyzer

### DIFF
--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -19,11 +19,33 @@ class IndirectCallAnalyzer:
         self.disassembly = self.disassembler.disassembly
         self.current_calling_addr = 0
         self.state = None
+        # Lazy {instruction_addr: containing_block} index, populated for the
+        # lifetime of a single resolveRegisterCalls() call. Cleared afterwards
+        # so a reused analyzer instance never serves a stale index.
+        self._block_index = None
+
+    @staticmethod
+    def _buildBlockIndex(analysis_state):
+        # Preserve "first matching block wins" — overlapping potential_starts
+        # in FunctionAnalysisState.getBlocks() can place the same instruction
+        # in more than one block; the legacy linear scan returned the first.
+        index = {}
+        for block in analysis_state.getBlocks():
+            for ins in block:
+                addr = ins[0]
+                if addr not in index:
+                    index[addr] = block
+        return index
 
     def searchBlock(self, analysis_state, address):
+        if self._block_index is not None:
+            return self._block_index.get(address, [])
+        # Fallback for direct callers (e.g. unit tests) that bypass
+        # resolveRegisterCalls and never seed the index.
         for block in analysis_state.getBlocks():
-            if address in [i[0] for i in block]:
-                return block
+            for ins in block:
+                if ins[0] == address:
+                    return block
         return []
 
     def getDword(self, addr):
@@ -209,38 +231,47 @@ class IndirectCallAnalyzer:
                 len(analysis_state.call_register_ins),
                 analysis_state.start_addr,
             )
-        max_calls_per_block = 10
-        calls_per_block = {}
-        for calling_addr in analysis_state.call_register_ins:
-            LOGGER.debug("#" * 20)
-            self.current_calling_addr = calling_addr
-            self.state = analysis_state
-            start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
-            if not start_block:
-                return
-            # we only process at most 10 register-calls per block to avoid extreme cases
-            # found one Go sample with 130k register calls.
-            if start_block[0] not in calls_per_block:
-                calls_per_block[start_block[0]] = 0
-            calls_per_block[start_block[0]] += 1
-            # if we have an old config, default to 50
-            max_calls = (
-                self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
-                if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
-                else 50
-            )
-            if calls_per_block[start_block[0]] > max_calls:
-                break
-            LOGGER.debug(
-                "For this block, we can still analyze %d indirect calls.",
-                max_calls_per_block - calls_per_block[start_block[0]],
-            )
-            if start_block:
-                self.processBlock(
-                    analysis_state,
-                    start_block,
-                    {},
-                    start_block[-1][3],
-                    [],
-                    block_depth,
+        # Build the instruction->block index once per function. The previous
+        # implementation scanned every block linearly inside searchBlock for
+        # every calling address AND recursively for every incoming ref up to
+        # block_depth — O(N**2) on call-heavy functions (e.g. Go binaries with
+        # many register calls). With the index, each lookup is O(1).
+        self._block_index = self._buildBlockIndex(analysis_state)
+        try:
+            max_calls_per_block = 10
+            calls_per_block = {}
+            for calling_addr in analysis_state.call_register_ins:
+                LOGGER.debug("#" * 20)
+                self.current_calling_addr = calling_addr
+                self.state = analysis_state
+                start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
+                if not start_block:
+                    return
+                # we only process at most 10 register-calls per block to avoid extreme cases
+                # found one Go sample with 130k register calls.
+                if start_block[0] not in calls_per_block:
+                    calls_per_block[start_block[0]] = 0
+                calls_per_block[start_block[0]] += 1
+                # if we have an old config, default to 50
+                max_calls = (
+                    self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
+                    if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
+                    else 50
                 )
+                if calls_per_block[start_block[0]] > max_calls:
+                    break
+                LOGGER.debug(
+                    "For this block, we can still analyze %d indirect calls.",
+                    max_calls_per_block - calls_per_block[start_block[0]],
+                )
+                if start_block:
+                    self.processBlock(
+                        analysis_state,
+                        start_block,
+                        {},
+                        start_block[-1][3],
+                        [],
+                        block_depth,
+                    )
+        finally:
+            self._block_index = None

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import re
 import struct
@@ -19,34 +20,32 @@ class IndirectCallAnalyzer:
         self.disassembly = self.disassembler.disassembly
         self.current_calling_addr = 0
         self.state = None
-        # Lazy {instruction_addr: containing_block} index, populated for the
-        # lifetime of a single resolveRegisterCalls() call. Cleared afterwards
-        # so a reused analyzer instance never serves a stale index.
-        self._block_index = None
-
-    @staticmethod
-    def _buildBlockIndex(analysis_state):
-        # Preserve "first matching block wins" — overlapping potential_starts
-        # in FunctionAnalysisState.getBlocks() can place the same instruction
-        # in more than one block; the legacy linear scan returned the first.
-        index = {}
-        for block in analysis_state.getBlocks():
-            for ins in block:
-                addr = ins[0]
-                if addr not in index:
-                    index[addr] = block
-        return index
 
     def searchBlock(self, analysis_state, address):
-        if self._block_index is not None:
-            return self._block_index.get(address, [])
-        # Fallback for direct callers (e.g. unit tests) that bypass
-        # resolveRegisterCalls and never seed the index.
-        for block in analysis_state.getBlocks():
-            for ins in block:
-                if ins[0] == address:
-                    return block
-        return []
+        # Lazy-cache an {instruction_addr: containing_block} index on the
+        # analysis_state so subsequent lookups during the same function
+        # analysis are O(1) instead of O(blocks * instructions). The cache
+        # lives on the state (not on self) so the analyzer stays
+        # re-entrancy-safe and the index can't outlive the function being
+        # analyzed.
+        block_index = getattr(analysis_state, "_block_index", None)
+        if not isinstance(block_index, dict):
+            block_index = {}
+            # Preserve "first matching block wins" — overlapping
+            # potential_starts in FunctionAnalysisState.getBlocks() can
+            # place the same instruction in more than one block; the
+            # legacy linear scan returned the first.
+            for block in analysis_state.getBlocks():
+                for ins in block:
+                    addr = ins[0]
+                    if addr not in block_index:
+                        block_index[addr] = block
+            # Objects with __slots__ or read-only attribute surfaces (and some
+            # test doubles) reject the assignment; the lookup below still works
+            # on the freshly built index.
+            with contextlib.suppress(AttributeError):
+                analysis_state._block_index = block_index
+        return block_index.get(address, [])
 
     def getDword(self, addr):
         if not self.disassembly.isAddrWithinMemoryImage(addr):
@@ -231,47 +230,38 @@ class IndirectCallAnalyzer:
                 len(analysis_state.call_register_ins),
                 analysis_state.start_addr,
             )
-        # Build the instruction->block index once per function. The previous
-        # implementation scanned every block linearly inside searchBlock for
-        # every calling address AND recursively for every incoming ref up to
-        # block_depth — O(N**2) on call-heavy functions (e.g. Go binaries with
-        # many register calls). With the index, each lookup is O(1).
-        self._block_index = self._buildBlockIndex(analysis_state)
-        try:
-            max_calls_per_block = 10
-            calls_per_block = {}
-            for calling_addr in analysis_state.call_register_ins:
-                LOGGER.debug("#" * 20)
-                self.current_calling_addr = calling_addr
-                self.state = analysis_state
-                start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
-                if not start_block:
-                    return
-                # we only process at most 10 register-calls per block to avoid extreme cases
-                # found one Go sample with 130k register calls.
-                if start_block[0] not in calls_per_block:
-                    calls_per_block[start_block[0]] = 0
-                calls_per_block[start_block[0]] += 1
-                # if we have an old config, default to 50
-                max_calls = (
-                    self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
-                    if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
-                    else 50
+        max_calls_per_block = 10
+        calls_per_block = {}
+        for calling_addr in analysis_state.call_register_ins:
+            LOGGER.debug("#" * 20)
+            self.current_calling_addr = calling_addr
+            self.state = analysis_state
+            start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
+            if not start_block:
+                return
+            # we only process at most 10 register-calls per block to avoid extreme cases
+            # found one Go sample with 130k register calls.
+            if start_block[0] not in calls_per_block:
+                calls_per_block[start_block[0]] = 0
+            calls_per_block[start_block[0]] += 1
+            # if we have an old config, default to 50
+            max_calls = (
+                self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
+                if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
+                else 50
+            )
+            if calls_per_block[start_block[0]] > max_calls:
+                break
+            LOGGER.debug(
+                "For this block, we can still analyze %d indirect calls.",
+                max_calls_per_block - calls_per_block[start_block[0]],
+            )
+            if start_block:
+                self.processBlock(
+                    analysis_state,
+                    start_block,
+                    {},
+                    start_block[-1][3],
+                    [],
+                    block_depth,
                 )
-                if calls_per_block[start_block[0]] > max_calls:
-                    break
-                LOGGER.debug(
-                    "For this block, we can still analyze %d indirect calls.",
-                    max_calls_per_block - calls_per_block[start_block[0]],
-                )
-                if start_block:
-                    self.processBlock(
-                        analysis_state,
-                        start_block,
-                        {},
-                        start_block[-1][3],
-                        [],
-                        block_depth,
-                    )
-        finally:
-            self._block_index = None


### PR DESCRIPTION
## Summary

Picks up the highest-impact deferred item from PR #46: collapse the O(B·I) linear scan in `IndirectCallAnalyzer.searchBlock` to an O(1) dict lookup. Single optimization class.

`resolveRegisterCalls` walks the CFG backward through up to `block_depth=3` levels of incoming refs to resolve `call <register>` targets. At every level, `searchBlock` was doing:

```python
for block in analysis_state.getBlocks():
    if address in [i[0] for i in block]:
        return block
```

One call is O(B·I). The recursive descent in `processBlock` makes that call once per incoming ref at every depth. Functions with many register calls (the file already mentions "found one Go sample with 130k register calls") hit this hard.

## Change

- Lazy-cache an `{instruction_addr: containing_block}` index **on `analysis_state`** the first time `searchBlock` runs. Subsequent lookups during the same function analysis are O(1).
- Cache lives on the state object (not on the analyzer), so the index has the correct lifetime (one per function analysis), the analyzer stays re-entrancy-safe, and direct callers (e.g. unit tests) get the O(1) path automatically — no separate fallback branch needed.
- Preserve **"first matching block wins"** by using `if addr not in index` during construction — important because `FunctionAnalysisState.getBlocks()` can place the same instruction in multiple overlapping blocks via the sorted `potential_starts` walk.
- `contextlib.suppress(AttributeError)` guards the cache write so test doubles or `__slots__`-locked states still work; the freshly built dict is returned in that case.

## Measurements

Microbench (synthetic 80 blocks × 15 instructions = 1200 lookups):

| Path | Best of 5 |
|---|---|
| legacy linear scan | 28.60 ms |
| indexed O(1) lookup | 0.27 ms |
| **speedup** | **~107×** |

Parity check on the same fixture: 1200 lookups, **0 mismatches** — both paths return the same block object reference.

End-to-end on asprox is unchanged (asprox is malware with mostly direct calls, so it doesn't stress `resolveRegisterCalls`). The win scales linearly with the number of indirect calls in the binary, which is high in Go and other compiler-heavy targets.

## Behavior compatibility

- Public API of `IndirectCallAnalyzer` unchanged (`searchBlock`, `processBlock`, `resolveRegisterCalls`, `getDword` all keep the same signatures).
- Same block-list reference identity returned for any given address.
- Report serialization untouched.
- asprox `sha256`, `num_instructions`, function count, and integration assertions unchanged.

## Test plan

- [x] `python -m pytest tests/test*` — 111 passed, 79 subtests passed in 12.63 s
- [x] `python -m ruff check .` — All checks passed
- [x] `python -m ruff format --check .` — 95 files already formatted
- [x] Microbench parity check — 1200/1200 identical block references
- [x] End-to-end asprox disassembly invariants verified

## Residual risk

- The cache is on `analysis_state`, so its lifetime is tied to the state object. If blocks were ever mutated after the first `searchBlock` call (currently they aren't — `resolveRegisterCalls` only runs after `finalizeAnalysis`), the index would go stale. The fix would be cache invalidation on the mutation site, not here.
- `contextlib.suppress(AttributeError)` is a deliberate fallback for objects that reject attribute assignment — for those the index is rebuilt on every call, which is no worse than the legacy O(B·I) scan.

## Still deferred (out of scope for this branch)

- `SmdaFunction.getNormalizedBlockRefs` caching (needs `architecture_metadata` mutation tracking).
- `BinaryInfo.getImportedFunctions` discards a `PeSymbolProvider.parseSymbols` result before re-parsing for imports.
- Static `*FileLoader.getArchitecture` / `getCodeAreas` each `lief.parse(binary)` — `BinaryInfo` caches but the static accessors don't share it.
- Dead `_logCandidateStats` + latent `== 2` vs `== 0` bug in `FunctionCandidateManager`.
- `mcrit-install` 3×5 CI matrix likely over-spec for a smoke test.

## Review follow-ups

- Gemini (PR #47, 2026-05-26): suggested moving the index cache off the analyzer and onto `analysis_state` to avoid re-entrancy/thread-safety risks and simplify `resolveRegisterCalls`. Applied in `1e0fc9c` — speedup reran at ~107× (up from ~92×) with the same 0/1200 parity, fallback branch and `try/finally` removed.

https://claude.ai/code/session_01C8CcS2k1g59ByLKYdEcaxR