### PR TITLE
perf(common): drop discarded PeSymbolProvider.parseSymbols in getImportedFunctions

### DIFF
--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -80,7 +80,6 @@ class BinaryInfo:
         if self.imported_functions is None:
             lief_result = self.getLiefBinary()
             if isinstance(lief_result, lief.PE.Binary):
-                PeSymbolProvider(None).parseSymbols(lief_result)
                 self.imported_functions = PeSymbolProvider(None).parseImports(lief_result)
             elif isinstance(lief_result, lief.ELF.Binary):
                 self.imported_functions = ElfSymbolProvider(None).parseSymbols(lief_result.dynamic_symbols)


### PR DESCRIPTION
## Summary

Picks up a deferred item from PR #46/47 final reports: `BinaryInfo.getImportedFunctions()` instantiated `PeSymbolProvider(None).parseSymbols(lief_result)` and threw away the return value before spinning up a *second* `PeSymbolProvider(None)` just to call `parseImports`. The first call walked `lief_binary.symbols` and built a function-symbol dict for nothing.

This removes the wasted call. `parseSymbols` is still invoked from `getSymbols()` and from `PeSymbolProvider.update()`, so symbol parsing is unchanged for callers that actually need it.

## Behavior compatibility

- `getImportedFunctions()` still returns the same dict (it was always the `parseImports` return value).
- `getSymbols()` unchanged.
- ELF path unchanged.
- No public API change.

## Test plan

- [x] `python -m pytest tests/test*` — 111 passed, 79 subtests passed
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — clean

https://claude.ai/code/session_01C8CcS2k1g59ByLKYdEcaxR

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8CcS2k1g59ByLKYdEcaxR)_