### PR TITLE
perf(common): cache getNormalizedBlockRefs on SmdaFunction

### DIFF
--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -276,6 +276,19 @@ class SmdaFunction:
         return None
 
     def getNormalizedBlockRefs(self):
+        # Cache: SmdaFunction construction (__init__ and fromDict) and the
+        # subsequent _calculateSccs / _calculateNestingDepth helpers each
+        # invoke this method, producing the same dict every time because
+        # self.blocks / self.blockrefs / self.architecture_metadata are
+        # immutable after construction. Caching avoids 2-3 redundant
+        # normalization passes per function. The cache key is the identity
+        # of those inputs; if any of them is reassigned externally, callers
+        # must clear self._normalized_blockrefs_cache to force a rebuild.
+        cached = getattr(self, "_normalized_blockrefs_cache", None)
+        if cached is not None:
+            cache_key, cache_value = cached
+            if cache_key == (id(self.blocks), id(self.blockrefs), id(self.architecture_metadata)):
+                return cache_value
         current_blockrefs = self.blockrefs or {}
         normalized_blockrefs = {
             block_start: sorted(current_blockrefs.get(block_start, [])) for block_start in self.blocks
@@ -306,7 +319,12 @@ class SmdaFunction:
                     successors = set(normalized_blockrefs.get(block_start, []))
                     successors.update(normalized_targets)
                     normalized_blockrefs[block_start] = sorted(successors)
-        return {block_start: normalized_blockrefs[block_start] for block_start in sorted(normalized_blockrefs)}
+        result = {block_start: normalized_blockrefs[block_start] for block_start in sorted(normalized_blockrefs)}
+        self._normalized_blockrefs_cache = (
+            (id(self.blocks), id(self.blockrefs), id(self.architecture_metadata)),
+            result,
+        )
+        return result
 
     def toDotGraph(self, with_api=False):
         dot_graph = f'digraph "CFG for 0x{self.offset:x}" {{\n'

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -281,13 +281,22 @@ class SmdaFunction:
         # invoke this method, producing the same dict every time because
         # self.blocks / self.blockrefs / self.architecture_metadata are
         # immutable after construction. Caching avoids 2-3 redundant
-        # normalization passes per function. The cache key is the identity
-        # of those inputs; if any of them is reassigned externally, callers
-        # must clear self._normalized_blockrefs_cache to force a rebuild.
+        # normalization passes per function.
+        #
+        # Subtlety: __init__ does `self.blockrefs = self.getNormalizedBlockRefs()`
+        # right after the first call, so on the next call self.blockrefs is
+        # the previously cached *result*, not the original input. We accept
+        # a cache hit either when self.blockrefs still has the input id or
+        # when it has been reassigned to the cached value itself. Any other
+        # reassignment is treated as a cache miss and recomputes.
         cached = getattr(self, "_normalized_blockrefs_cache", None)
         if cached is not None:
             cache_key, cache_value = cached
-            if cache_key == (id(self.blocks), id(self.blockrefs), id(self.architecture_metadata)):
+            if (
+                cache_key[0] == id(self.blocks)
+                and cache_key[2] == id(self.architecture_metadata)
+                and (cache_key[1] == id(self.blockrefs) or id(cache_value) == id(self.blockrefs))
+            ):
                 return cache_value
         current_blockrefs = self.blockrefs or {}
         normalized_blockrefs = {


### PR DESCRIPTION
## Summary

Picks up the `getNormalizedBlockRefs` deferred item from PR #46/47. `SmdaFunction.__init__` and `SmdaFunction.fromDict` each call `getNormalizedBlockRefs()`; the result then gets recomputed two more times if `CALCULATE_SCC` and `CALCULATE_NESTING` are on (both default to `True`) because `_calculateSccs` and `_calculateNestingDepth` each call `getNormalizedBlockRefs()` again. The normalization is idempotent (re-normalizing already-normalized blockrefs returns the same dict), so the redundant passes are pure wasted work for every analyzed function.

## Change

Memoize the result keyed by `(id(self.blocks), id(self.blockrefs), id(self.architecture_metadata))`. Reassigning any of those input attributes invalidates the cache automatically because the id changes; SMDA only ever assigns those during `__init__` / `_parseBlocks` / `fromDict`, so the cache is built once per function and reused. Callers that need to recompute can clear `self._normalized_blockrefs_cache` explicitly.

## Measurements

Microbench on the asprox fixture (105 functions, 200 normalization passes each):

| Path | Total |
|---|---|
| cached | 7.0 ms |
| forced recompute | 154.3 ms |
| **speedup** | **~22×** |

Subsequent calls return the same dict object (verified by `is`-identity).

## Behavior compatibility

- `getNormalizedBlockRefs()` returns the same dict it did before — verified by `pic_hash` / `opc_hash` / serialized `sha256` / `num_instructions` being unchanged on asprox.
- Public API of `SmdaFunction` unchanged.
- Cache invalidation: id-based, so any in-place mutation of `self.blocks` / `self.blockrefs` / `self.architecture_metadata` would not invalidate. Verified `grep` of `src/`: those attrs are only assigned (not mutated) during `__init__` / `_parseBlocks` / `fromDict`. Safe.

## Test plan

- [x] `python -m pytest tests/test*` — 111 passed, 79 subtests passed
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — clean
- [x] asprox `sha256` / `num_instructions` / function count unchanged
- [x] Microbench parity check — cached path returns same dict object across calls

https://claude.ai/code/session_01C8CcS2k1g59ByLKYdEcaxR

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8CcS2k1g59ByLKYdEcaxR)_