### PR TITLE
refactor(ida)!: migrate IDA backend to ida-domain API, drop legacy IDAPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ There is also a demo script:
 
 * analyze.py -- example usage: perform disassembly on a file or memory dump and optionally store results in JSON to a given output path.
 
+### IDA Pro export
+
+SMDA can also turn an IDA-analyzed database into a SMDA report instead of running its own disassembly. The IDA backend (`smda.ida.IdaInterface`) is built on the [IDA Domain API](https://ida-domain.docs.hex-rays.com/) and ships by default with `pip install smda` (the `ida-domain` dependency is included). Using it requires a licensed **IDA Pro 9.1+** installation with `IDADIR` configured.
+
+> The older IDAPython-based backend (IDA 7.x/8.x) has been removed; SMDA now targets IDA 9.1+ via the IDA Domain API only.
+
+Inside the IDA GUI, run `export.py` (dumps a `.smda` next to the database) or `ida_analyze.py` (pushes recovered functions/names back into IDA) via *File -> Script file...*.
+
+For headless export (no GUI), use `ida_domain_analyze.py`:
+
+```
+python ida_domain_analyze.py /path/to/sample.i64 -o sample.smda
+```
+
+Make sure `IDADIR` points at your IDA Pro 9.1+ installation (see the [getting started guide](https://ida-domain.docs.hex-rays.com/getting_started/)).
+
 For Dalvik, the current scope is raw single-DEX inputs. APK, multi-dex container handling, and ODEX/VDEX/CDEX runtime-artifact analysis are not yet first-class workflows in SMDA.
 
 The code should be fully compatible with Python 3.8+.

--- a/export.py
+++ b/export.py
@@ -1,16 +1,26 @@
+"""Run from inside IDA (File -> Script file...) to export the currently open
+database as a SMDA report, using the ida-domain backend (IDA Pro 9.1+).
+
+For headless export (no GUI) use ``ida_domain_analyze.py`` instead.
+"""
+
 import json
 
 from smda.Disassembler import Disassembler
+from smda.ida.IdaExporter import IdaExporter
+from smda.ida.IdaInterface import IdaInterface
+from smda.SmdaConfig import SmdaConfig
 
 
 def detectBackend():
+    """Return ("IDA", "ida-domain") when the ida-domain backend is importable."""
     backend = ""
     version = ""
     try:
-        import idaapi
+        import ida_domain  # noqa: F401
 
         backend = "IDA"
-        version = idaapi.IDA_SDK_VERSION
+        version = getattr(ida_domain, "__version__", "ida-domain")
     except ImportError:
         pass
     return (backend, version)
@@ -19,17 +29,17 @@ def detectBackend():
 if __name__ == "__main__":
     BACKEND, VERSION = detectBackend()
     if BACKEND == "IDA":
-        from smda.ida.IdaInterface import IdaInterface
-
+        config = SmdaConfig()
+        disassembler = Disassembler(config)
         ida_interface = IdaInterface()
+        disassembler.disassembler = IdaExporter(config, ida_interface=ida_interface)
+        disassembler._explicit_backend = True
         binary = ida_interface.getBinary()
         base_addr = ida_interface.getBaseAddr()
-        DISASSEMBLER = Disassembler(backend=BACKEND)
-        REPORT = DISASSEMBLER.disassembleBuffer(binary, base_addr)
-        output_path = ida_interface.getIdbDir()
-        output_filepath = output_path + "ConvertedFromIdb.smda"
+        REPORT = disassembler.disassembleBuffer(binary, base_addr)
+        output_filepath = ida_interface.getIdbDir() + "ConvertedFromIdb.smda"
         with open(output_filepath, "w") as fout:
             json.dump(REPORT.toDict(), fout, indent=1, sort_keys=True)
             print(f"Output saved to: {output_filepath}")
     else:
-        raise Exception("No supported backend found.")
+        raise Exception("No supported backend found (ida-domain is required, IDA Pro 9.1+).")

--- a/ida_analyze.py
+++ b/ida_analyze.py
@@ -5,6 +5,7 @@ IDA. Uses the ida-domain backend (IDA Pro 9.1+).
 
 from export import detectBackend
 from smda.Disassembler import Disassembler
+from smda.ida.IdaExporter import IdaExporter
 from smda.ida.IdaInterface import IdaInterface
 from smda.SmdaConfig import SmdaConfig
 
@@ -16,6 +17,8 @@ if __name__ == "__main__":
         base_addr = ida_interface.getBaseAddr()
         config = SmdaConfig()
         DISASSEMBLER = Disassembler(config)
+        DISASSEMBLER.disassembler = IdaExporter(config, ida_interface=ida_interface)
+        DISASSEMBLER._explicit_backend = True
         REPORT = DISASSEMBLER.disassembleBuffer(binary, base_addr)
         smda_function_count = 0
         smda_name_count = 0

--- a/ida_analyze.py
+++ b/ida_analyze.py
@@ -1,12 +1,16 @@
+"""Run from inside IDA (File -> Script file...) to disassemble the currently
+open database with SMDA and push the recovered functions and names back into
+IDA. Uses the ida-domain backend (IDA Pro 9.1+).
+"""
+
 from export import detectBackend
 from smda.Disassembler import Disassembler
+from smda.ida.IdaInterface import IdaInterface
 from smda.SmdaConfig import SmdaConfig
 
 if __name__ == "__main__":
     BACKEND, VERSION = detectBackend()
     if BACKEND == "IDA":
-        from smda.ida.IdaInterface import IdaInterface
-
         ida_interface = IdaInterface()
         binary = ida_interface.getBinary()
         base_addr = ida_interface.getBaseAddr()
@@ -21,4 +25,4 @@ if __name__ == "__main__":
                 smda_name_count += ida_interface.makeNameEx(smda_function.offset, smda_function.function_name)
         print(f"Defined {smda_function_count} functions and assigned {smda_name_count} function names.")
     else:
-        raise Exception("Run this script from within IDA.")
+        raise Exception("Run this script from within IDA (ida-domain required, IDA Pro 9.1+).")

--- a/ida_domain_analyze.py
+++ b/ida_domain_analyze.py
@@ -1,0 +1,65 @@
+"""Headless SMDA export using the modern ``ida-domain`` backend.
+
+This opens an IDA database (``.idb``/``.i64``) or any input binary IDA supports
+*without* a running IDA GUI, collects the disassembly via ``ida-domain`` and
+writes a ``.smda`` report - the headless counterpart to ``export.py`` (which
+must be run from inside IDA).
+
+Requirements:
+    pip install "smda[ida]"   # pulls in ida-domain >= 0.5.0
+    IDA Pro 9.1+ with IDADIR configured (see
+    https://ida-domain.docs.hex-rays.com/getting_started/)
+
+Usage:
+    python ida_domain_analyze.py /path/to/sample.i64 [-o report.smda]
+"""
+
+import argparse
+import json
+import sys
+
+from smda.Disassembler import Disassembler
+from smda.ida.IdaExporter import IdaExporter
+from smda.ida.IdaInterface import IdaInterface
+from smda.SmdaConfig import SmdaConfig
+
+
+def analyze(input_path, output_path=None):
+    config = SmdaConfig()
+    disassembler = Disassembler(config)
+    with IdaInterface.fromPath(input_path) as ida_interface:
+        # inject the ida-domain backed interface into the exporter and mark the
+        # backend explicit so buffer disassembly does not try to auto-detect.
+        disassembler.disassembler = IdaExporter(config, ida_interface=ida_interface)
+        disassembler._explicit_backend = True
+        binary = ida_interface.getBinary()
+        base_addr = ida_interface.getBaseAddr()
+        report = disassembler.disassembleBuffer(binary, base_addr)
+    if output_path is None:
+        output_path = input_path + ".smda"
+    with open(output_path, "w") as fout:
+        json.dump(report.toDict(), fout, indent=1, sort_keys=True)
+    print(f"Disassembled {report.num_functions} functions.")
+    print(f"Output saved to: {output_path}")
+    return report
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Headless SMDA export via the ida-domain backend.")
+    parser.add_argument("input_path", help="Path to the IDA database (.idb/.i64) or input binary to analyze.")
+    parser.add_argument("-o", "--output", help="Output .smda path (default: <input_path>.smda).")
+    args = parser.parse_args(argv)
+    try:
+        analyze(args.input_path, args.output)
+    except ImportError:
+        print(
+            "ida-domain is not available. Install it with 'pip install \"smda[ida]\"' "
+            "and configure IDADIR for an IDA Pro 9.1+ installation.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "dncil",
     "dnfile",
     "lief>=0.16.0",
+    "ida-domain>=0.5.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ruff
 pre-commit
 build
 twine
+ida-domain>=0.5.0

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -239,8 +239,13 @@ class Disassembler:
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
+        report.timestamp = datetime.datetime.now(datetime.timezone.utc)
         report.execution_time = self._getDurationInSeconds(start, datetime.datetime.now(datetime.timezone.utc))
         report.message = traceback.format_exc()
+        report.xcfg = {}
+        report.data_refs_from = {}
+        report.data_refs_to = {}
+        report.xmetadata = {}
         return report
 
     def _handleDisassemblyException(self, start, exception, log_message):

--- a/src/smda/ida/IdaExporter.py
+++ b/src/smda/ida/IdaExporter.py
@@ -11,9 +11,11 @@ LOGGER = logging.getLogger(__name__)
 
 
 class IdaExporter:
-    def __init__(self, config, bitness=None):
+    def __init__(self, config, bitness=None, ida_interface=None):
         self.config = config
-        self.ida_interface = IdaInterface()
+        # backend is the ida-domain based interface; when none is injected we
+        # grab a handle to the database currently open in the IDA GUI.
+        self.ida_interface = ida_interface if ida_interface is not None else IdaInterface()
         self.bitness = bitness if bitness else self.ida_interface.getBitness()
         self.capstone = None
         self.disassembly = DisassemblyResult()

--- a/src/smda/ida/IdaInterface.py
+++ b/src/smda/ida/IdaInterface.py
@@ -19,9 +19,15 @@ import re
 
 from .BackendInterface import BackendInterface
 
+Database = None
 with contextlib.suppress(ImportError):
     # only importable when ida-domain (and an IDA installation) is available
     from ida_domain import Database
+
+_IDA_DOMAIN_MISSING = (
+    "ida-domain is not available. Install it with 'pip install ida-domain' and "
+    "ensure IDA Pro 9.1+ is installed with IDADIR configured."
+)
 
 
 # processor identifiers that SMDA maps onto its "intel" architecture
@@ -52,6 +58,8 @@ class IdaInterface(BackendInterface):
         if database is not None:
             self.db = database
         else:
+            if Database is None:
+                raise ImportError(_IDA_DOMAIN_MISSING)
             # inside the IDA GUI: get a handle to the currently open database
             self.db = Database.open()
         self._processor_map = dict.fromkeys(_INTEL_PROCESSORS, "intel")
@@ -63,6 +71,8 @@ class IdaInterface(BackendInterface):
         The caller is responsible for keeping the interface alive while the
         report is being built; call :meth:`close` when done.
         """
+        if Database is None:
+            raise ImportError(_IDA_DOMAIN_MISSING)
         database = Database.open(path=input_path, save_on_close=save_on_close)
         interface = cls(database=database)
         interface._owns_database = True
@@ -124,6 +134,8 @@ class IdaInterface(BackendInterface):
 
     def getInstructionBytes(self, offset):
         instruction = self.db.instructions.get_at(offset)
+        if instruction is None:
+            return b""
         return self.db.bytes.get_bytes_at(offset, instruction.size)
 
     def getCodeInRefs(self, offset):
@@ -195,4 +207,5 @@ class IdaInterface(BackendInterface):
     def getIdbDir(self):
         if not self.db.path:
             return ""
-        return os.path.dirname(self.db.path) + os.sep
+        dirname = os.path.dirname(self.db.path)
+        return dirname + os.sep if dirname else ""

--- a/src/smda/ida/IdaInterface.py
+++ b/src/smda/ida/IdaInterface.py
@@ -1,396 +1,198 @@
+"""SMDA's IDA backend, built on the modern ``ida-domain`` package.
+
+This is the single supported IDA backend (SMDA dropped the legacy IDAPython
+``idaapi``/``idautils``/``idc`` interface). It drives the high level
+``ida_domain.Database`` handle and works both:
+
+* inside the IDA GUI - construct it without a database handle and it grabs the
+  currently open one via ``Database.open()``; and
+* fully headless - open a database from disk (``.idb``/``.i64`` or any input
+  binary IDA supports) and hand the resulting handle to this class.
+
+Requires ``ida-domain >= 0.5.0`` and IDA Pro 9.1+.  See
+https://ida-domain.docs.hex-rays.com/ for the API reference.
+"""
+
 import contextlib
+import os
 import re
 
 from .BackendInterface import BackendInterface
 
-try:
-    import idaapi
-    import idautils
-except ImportError:
-    pass
-
-try:
-    # we only need these when we are in IDA - IDA 7.4 and above
-    import ida_bytes
-    import ida_funcs
-    import ida_gdl
-    import ida_idaapi
-    import ida_nalt
-    import ida_name
-    import ida_segment
-except ImportError:
-    pass
-
 with contextlib.suppress(ImportError):
-    # we only need these when we are in IDA - IDA 7.3 and below
-    import idc
+    # only importable when ida-domain (and an IDA installation) is available
+    from ida_domain import Database
 
 
-class IdaInterface:
-    # derived from https://python-3-patterns-idioms-test.readthedocs.io/en/latest/Singleton.html
-    instance = None
-
-    def __init__(self):
-        if not IdaInterface.instance:
-            sdk_version = idaapi.IDA_SDK_VERSION
-            if not isinstance(sdk_version, int):
-                raise ValueError("Unsupported IDA SDK version")
-            if sdk_version < 740:
-                IdaInterface.instance = Ida73Interface()
-            elif sdk_version < 850:
-                IdaInterface.instance = Ida74Interface()
-            else:
-                IdaInterface.instance = Ida85Interface()
-
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
-
-    def getIdbDir(self):
-        return idautils.GetIdbDir()
+# processor identifiers that SMDA maps onto its "intel" architecture
+_INTEL_PROCESSORS = {
+    "metapc",
+    "8086",
+    "80286p",
+    "80386p",
+    "80486p",
+    "80586p",
+    "80686p",
+    "p2",
+    "p3",
+    "p4",
+    "x86",
+    "x86_64",
+    "x64",
+}
 
 
-class Ida74Interface(BackendInterface):
-    def __init__(self):
-        self.version = "IDA Pro 7.4 - 8.4"
-        self._processor_map = {"metapc": "intel"}
-        self._api_map = {}
-        self._import_module_name = ""
+class IdaInterface(BackendInterface):
+    """``BackendInterface`` implementation backed by ``ida_domain.Database``."""
+
+    def __init__(self, database=None):
+        super().__init__()
+        self.version = "ida-domain (IDA Pro 9.1+)"
+        self._owns_database = False
+        if database is not None:
+            self.db = database
+        else:
+            # inside the IDA GUI: get a handle to the currently open database
+            self.db = Database.open()
+        self._processor_map = dict.fromkeys(_INTEL_PROCESSORS, "intel")
+
+    @classmethod
+    def fromPath(cls, input_path, save_on_close=False):
+        """Open a database headlessly from ``input_path`` and wrap it.
+
+        The caller is responsible for keeping the interface alive while the
+        report is being built; call :meth:`close` when done.
+        """
+        database = Database.open(path=input_path, save_on_close=save_on_close)
+        interface = cls(database=database)
+        interface._owns_database = True
+        return interface
+
+    def close(self):
+        """Close the underlying database if this interface opened it."""
+        if self._owns_database and self.db is not None:
+            self.db.close()
+            self.db = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False
 
     def getArchitecture(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        info = ida_idaapi.get_inf_structure()
-        procname = info.procname if idaapi.IDA_SDK_VERSION >= 800 else info.procName
-        if procname in self._processor_map:
-            return self._processor_map[procname]
-        else:
+        procname = self.db.architecture
+        if procname is None:
             raise ValueError("Unsupported Architecture")
+        normalized = procname.lower()
+        if normalized in self._processor_map:
+            return self._processor_map[normalized]
+        # tolerate vendor specific suffixes like "x86_64-pc-linux"
+        if "x86" in normalized or normalized.startswith("metapc"):
+            return "intel"
+        raise ValueError(f"Unsupported Architecture: {procname}")
 
     def getBitness(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        bits = None
-        info = ida_idaapi.get_inf_structure()
-        if info.is_64bit():
-            bits = 64
-        elif info.is_32bit():
-            bits = 32
-        else:
-            bits = 16
-        return bits
+        bits = self.db.bitness
+        if bits in (16, 32, 64):
+            return bits
+        # ida-domain only advertises 32/64; fall back to the segment addressing
+        # mode for the (rare) 16 bit case.
+        segment = self.db.segments.get_at(self.db.minimum_ea)
+        if segment is not None:
+            return self.db.segments.get_bitness(segment)
+        return bits if bits else 32
 
     def getFunctions(self):
-        return sorted(idautils.Functions())
+        return sorted(func.start_ea for func in self.db.functions.get_all())
 
     def getBlocks(self, function_offset):
         blocks = []
-        function_chart = ida_gdl.FlowChart(ida_funcs.get_func(function_offset))
-        for block in function_chart:
-            extracted_block = []
-            for instruction in idautils.Heads(block.start_ea, block.end_ea):
-                if ida_bytes.is_code(ida_bytes.get_flags(instruction)):
-                    extracted_block.append(instruction)
+        func = self.db.functions.get_at(function_offset)
+        if func is None:
+            return blocks
+        flowchart = self.db.functions.get_flowchart(func)
+        if flowchart is None:
+            return blocks
+        for block in flowchart:
+            instructions = block.get_instructions()
+            extracted_block = [instruction.ea for instruction in instructions] if instructions else []
             if extracted_block:
                 blocks.append(extracted_block)
         return sorted(blocks)
 
     def getInstructionBytes(self, offset):
-        ins = idautils.DecodeInstruction(offset)
-        ins_bytes = ida_bytes.get_bytes(offset, ins.size)
-        return ins_bytes
+        instruction = self.db.instructions.get_at(offset)
+        return self.db.bytes.get_bytes_at(offset, instruction.size)
 
     def getCodeInRefs(self, offset):
-        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
+        return [(ref_from, offset) for ref_from in self.db.xrefs.code_refs_to_ea(offset, flow=True)]
 
     def getCodeOutRefs(self, offset):
-        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
+        return [(offset, ref_to) for ref_to in self.db.xrefs.code_refs_from_ea(offset, flow=True)]
 
     def getFunctionSymbols(self, demangle=False):
         function_symbols = {}
-        function_offsets = self.getFunctions()
-        for function_offset in function_offsets:
-            function_name = ida_funcs.get_func_name(function_offset)
+        for func in self.db.functions.get_all():
+            function_offset = func.start_ea
+            function_name = self.db.functions.get_name(func)
             # apply demangling if required
-            if demangle and "@" in function_name:
-                demangled = ida_name.demangle_name(function_name, 0)
+            if demangle and function_name and "@" in function_name:
+                demangled = self.db.names.get_demangled_name(function_offset)
                 if demangled:
                     function_name = demangled
-            if not re.match("sub_[0-9a-fA-F]+", function_name):
+            if function_name and not re.match("sub_[0-9a-fA-F]+", function_name):
                 function_symbols[function_offset] = function_name
         return function_symbols
 
     def getBaseAddr(self):
-        base_addr = 0
-        segment_starts = list(idautils.Segments())
-        if segment_starts:
-            first_segment_start = segment_starts[0]
-            # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start // 0x10000) * 0x10000
-            base_addr = int(first_segment_start)
-        return base_addr
-
-    def getBinary(self):
-        result = b""
-        segment = ida_segment.get_first_seg()
-        while segment:
-            result += ida_bytes.get_bytes(segment.start_ea, segment.end_ea - segment.start_ea)
-            segment = ida_segment.get_next_seg(segment.end_ea - 1)
-        return result
-
-    def getApiMap(self):
-        self._api_map = {}
-        num_imports = ida_nalt.get_import_module_qty()
-        for i in range(num_imports):
-            self._import_module_name = ida_nalt.get_import_module_name(i)
-            ida_nalt.enum_import_names(i, self._cbEnumImports)
-        return self._api_map
-
-    def isExternalFunction(self, function_offset):
-        function_segment = ida_segment.getseg(function_offset)
-        function_segment_name = ida_segment.get_segm_name(function_segment)
-        is_extern = function_segment_name in ["extern", "UNDEF"]
-        return is_extern
-
-    def makeFunction(self, instruction):
-        return ida_funcs.add_func(instruction)
-
-    def makeNameEx(self, address, name, warning_level=None):
-        if warning_level is None:
-            warning_level = idc.SN_NOWARN
-        return idc.set_name(address, name, warning_level)
-
-    def _cbEnumImports(self, addr, name, ordinal):
-        # potentially use: idc.Name(addr)
-        if self._import_module_name:
-            self._api_map[addr] = self._import_module_name + "!" + name
-        else:
-            self._api_map[addr] = name
-        return True
-
-
-class Ida73Interface(BackendInterface):
-    def __init__(self):
-        self.version = "IDA Pro 7.3 and below"
-        self._processor_map = {"metapc": "intel"}
-        self._api_map = {}
-        self._import_module_name = ""
-
-    def getArchitecture(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        info = idaapi.get_inf_structure()
-        procname = info.procName
-        if procname in self._processor_map:
-            return self._processor_map[procname]
-        else:
-            raise ValueError("Unsupported Architecture")
-
-    def getBitness(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        bits = None
-        info = idaapi.get_inf_structure()
-        if info.is_64bit():
-            bits = 64
-        elif info.is_32bit():
-            bits = 32
-        else:
-            bits = 16
-        return bits
-
-    def getFunctions(self):
-        return sorted(idautils.Functions())
-
-    def getBlocks(self, function_offset):
-        blocks = []
-        function_chart = idaapi.FlowChart(idaapi.get_func(function_offset))
-        for block in function_chart:
-            extracted_block = []
-            for instruction in idautils.Heads(block.startEA, block.endEA):
-                if idc.isCode(idc.GetFlags(instruction)):
-                    extracted_block.append(instruction)
-            if extracted_block:
-                blocks.append(extracted_block)
-        return sorted(blocks)
-
-    def getInstructionBytes(self, offset):
-        ins = idautils.DecodeInstruction(offset)
-        ins_bytes = idc.get_bytes(offset, ins.size)
-        return ins_bytes
-
-    def getCodeInRefs(self, offset):
-        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
-
-    def getCodeOutRefs(self, offset):
-        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
-
-    def getFunctionSymbols(self, demangle=False):
-        function_symbols = {}
-        function_offsets = self.getFunctions()
-        for function_offset in function_offsets:
-            function_name = idc.GetFunctionName(function_offset)
-            # apply demangling if required
-            if demangle and "@" in function_name:
-                function_name = idc.demangle_name(function_name, 0)
-            if not re.match("sub_[0-9a-fA-F]+", function_name):
-                function_symbols[function_offset] = function_name
-        return function_symbols
-
-    def getBaseAddr(self):
-        segment_starts = list(idautils.Segments())
+        segment_starts = sorted(segment.start_ea for segment in self.db.segments.get_all())
         if not segment_starts:
             return 0
         first_segment_start = segment_starts[0]
-        # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
+        # re-align by 0x10000 to reflect typical allocation behaviour for IDA-mapped binaries
         first_segment_start = (first_segment_start // 0x10000) * 0x10000
         return int(first_segment_start)
 
     def getBinary(self):
         result = b""
-        segment_starts = list(idautils.Segments())
-        offsets = []
-        start_len = 0
-        for start in segment_starts:
-            end = idc.SegEnd(start)
-            result += idc.get_bytes(start, end - start)
-            offsets.append((start, start_len, len(result)))
-            start_len = len(result)
+        for segment in sorted(self.db.segments.get_all(), key=lambda seg: seg.start_ea):
+            size = self.db.segments.get_size(segment)
+            segment_bytes = self.db.bytes.get_bytes_at(segment.start_ea, size)
+            if segment_bytes:
+                result += segment_bytes
         return result
 
     def getApiMap(self):
-        self._api_map = {}
-        num_imports = idaapi.get_import_module_qty()
-        for i in range(num_imports):
-            self._import_module_name = idaapi.get_import_module_name(i)
-            idaapi.enum_import_names(i, self._cbEnumImports)
-        return self._api_map
+        api_map = {}
+        for imported in self.db.imports.get_all_imports():
+            if imported.module_name and imported.name:
+                api_map[imported.address] = f"{imported.module_name}!{imported.name}"
+            elif imported.name:
+                api_map[imported.address] = imported.name
+            else:
+                # ordinal-only import
+                api_map[imported.address] = f"{imported.module_name}!#{imported.ordinal}"
+        return api_map
 
     def isExternalFunction(self, function_offset):
-        # TODO look up older function names to support this for IDA 7.3- as well
-        return False
+        segment = self.db.segments.get_at(function_offset)
+        if segment is None:
+            return False
+        segment_name = self.db.segments.get_name(segment)
+        return segment_name in ("extern", "UNDEF")
 
     def makeFunction(self, instruction):
-        return idc.add_func(instruction)
+        return self.db.functions.create(instruction)
 
     def makeNameEx(self, address, name, warning_level=None):
-        if warning_level is None:
-            warning_level = idc.SN_NOWARN
-        return idc.set_name(address, name, warning_level)
+        return self.db.names.set_name(address, name)
 
-    def _cbEnumImports(self, addr, name, ordinal):
-        # potentially use: idc.Name(addr)
-        if self._import_module_name:
-            self._api_map[addr] = self._import_module_name + "!" + name
-        else:
-            self._api_map[addr] = name
-        return True
+    def getInputPath(self):
+        return self.db.path
 
-
-class Ida85Interface(BackendInterface):
-    def __init__(self):
-        self.version = "IDA Pro 8.5+"
-        self._processor_map = {"metapc": "intel"}
-        self._api_map = {}
-        self._import_module_name = ""
-
-    def getArchitecture(self):
-        procname = idaapi.inf_get_procname()
-        if procname in self._processor_map:
-            return self._processor_map[procname]
-        else:
-            raise ValueError("Unsupported Architecture")
-
-    def getBitness(self):
-        # https://blog.junron.dev/IDAPython%20Research/IDAPython%208%20to%209.html#idaapi-get-inf-structure
-        bits = None
-        if idaapi.inf_is_64bit():
-            bits = 64
-        elif idaapi.inf_is_32bit_exactly():
-            bits = 32
-        else:
-            bits = 16
-        return bits
-
-    def getFunctions(self):
-        return sorted(idautils.Functions())
-
-    def getBlocks(self, function_offset):
-        blocks = []
-        function_chart = ida_gdl.FlowChart(ida_funcs.get_func(function_offset))
-        for block in function_chart:
-            extracted_block = []
-            for instruction in idautils.Heads(block.start_ea, block.end_ea):
-                if ida_bytes.is_code(ida_bytes.get_flags(instruction)):
-                    extracted_block.append(instruction)
-            if extracted_block:
-                blocks.append(extracted_block)
-        return sorted(blocks)
-
-    def getInstructionBytes(self, offset):
-        ins = idautils.DecodeInstruction(offset)
-        ins_bytes = ida_bytes.get_bytes(offset, ins.size)
-        return ins_bytes
-
-    def getCodeInRefs(self, offset):
-        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
-
-    def getCodeOutRefs(self, offset):
-        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
-
-    def getFunctionSymbols(self, demangle=False):
-        function_symbols = {}
-        function_offsets = self.getFunctions()
-        for function_offset in function_offsets:
-            function_name = ida_funcs.get_func_name(function_offset)
-            # apply demangling if required
-            if demangle and "@" in function_name:
-                demangled = ida_name.demangle_name(function_name, 0)
-                if demangled:
-                    function_name = demangled
-            if not re.match("sub_[0-9a-fA-F]+", function_name):
-                function_symbols[function_offset] = function_name
-        return function_symbols
-
-    def getBaseAddr(self):
-        base_addr = 0
-        segment_starts = list(idautils.Segments())
-        if segment_starts:
-            first_segment_start = segment_starts[0]
-            # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start // 0x10000) * 0x10000
-            base_addr = int(first_segment_start)
-        return base_addr
-
-    def getBinary(self):
-        result = b""
-        segment = ida_segment.get_first_seg()
-        while segment:
-            result += ida_bytes.get_bytes(segment.start_ea, segment.end_ea - segment.start_ea)
-            segment = ida_segment.get_next_seg(segment.end_ea - 1)
-        return result
-
-    def getApiMap(self):
-        self._api_map = {}
-        num_imports = ida_nalt.get_import_module_qty()
-        for i in range(num_imports):
-            self._import_module_name = ida_nalt.get_import_module_name(i)
-            ida_nalt.enum_import_names(i, self._cbEnumImports)
-        return self._api_map
-
-    def isExternalFunction(self, function_offset):
-        function_segment = ida_segment.getseg(function_offset)
-        function_segment_name = ida_segment.get_segm_name(function_segment)
-        is_extern = function_segment_name in ["extern", "UNDEF"]
-        return is_extern
-
-    def makeFunction(self, instruction):
-        return ida_funcs.add_func(instruction)
-
-    def makeNameEx(self, address, name, warning_level=None):
-        if warning_level is None:
-            warning_level = idc.SN_NOWARN
-        return idc.set_name(address, name, warning_level)
-
-    def _cbEnumImports(self, addr, name, ordinal):
-        # potentially use: idc.Name(addr)
-        if self._import_module_name:
-            self._api_map[addr] = self._import_module_name + "!" + name
-        else:
-            self._api_map[addr] = name
-        return True
+    def getIdbDir(self):
+        if not self.db.path:
+            return ""
+        return os.path.dirname(self.db.path) + os.sep

--- a/src/smda/ida/IdaInterface.py
+++ b/src/smda/ida/IdaInterface.py
@@ -126,6 +126,10 @@ class IdaInterface(BackendInterface):
         if flowchart is None:
             return blocks
         for block in flowchart:
+            start_ea = getattr(block, "start_ea", None)
+            end_ea = getattr(block, "end_ea", None)
+            if start_ea is not None and end_ea is not None and start_ea >= end_ea:
+                continue
             instructions = block.get_instructions()
             extracted_block = [instruction.ea for instruction in instructions] if instructions else []
             if extracted_block:


### PR DESCRIPTION
## Summary

Replaces SMDA's legacy IDAPython backend (`idaapi`/`idautils`/`idc`, the `Ida73/74/85Interface` classes) with a single backend built on the modern [IDA Domain API](https://ida-domain.docs.hex-rays.com/). SMDA's IDA integration now targets **IDA Pro 9.1+ only**.

### Changes
- **`src/smda/ida/IdaInterface.py`** — rewritten on top of `ida_domain.Database`, keeping the historic file/class name. Works both inside the IDA GUI (`IdaInterface()` → `Database.open()`) and fully headless (`IdaInterface.fromPath()` context manager).
- **`src/smda/ida/IdaExporter.py`** — defaults to the ida-domain backed `IdaInterface`; still supports interface injection via `ida_interface=`.
- **`ida_domain_analyze.py`** — new headless export entry point (open a `.idb`/`.i64` by path, no GUI → `.smda`).
- **`export.py` / `ida_analyze.py`** — refactored to the ida-domain backend; `detectBackend()` now probes `import ida_domain`.
- **`pyproject.toml` / `requirements.txt`** — `ida-domain>=0.5.0` is now a core dependency (installed by `pip install smda`). Actually using the backend still needs a licensed IDA Pro 9.1+ with `IDADIR` configured.
- **`README.md`** — documents the IDA 9.1+ / Domain-API-only backend and the headless workflow.

### Breaking change
The legacy IDAPython backend supporting IDA 7.x/8.x has been removed. Exports now require IDA Pro 9.1+.

## Validation
- `make lint` → ruff: **All checks passed!**
- `make test` → **111 passed** (79 subtests)
- The IDA backend itself is not exercised by CI (no IDA Pro available); the runtime path against a real database is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)