### PR TITLE
ci: trim redundant mcrit-install matrix combos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # Verify mcrit install across every supported Python on the primary
+        # (ubuntu) runner, but only on the boundary versions (oldest/newest) for
+        # the costlier windows/macos runners. Middle minor versions on those
+        # platforms add little signal beyond the boundary checks, which already
+        # exercise each OS's native-wheel install path.
+        include:
+          - { os: ubuntu-latest, python-version: "3.10" }
+          - { os: ubuntu-latest, python-version: "3.11" }
+          - { os: ubuntu-latest, python-version: "3.12" }
+          - { os: ubuntu-latest, python-version: "3.13" }
+          - { os: ubuntu-latest, python-version: "3.14" }
+          - { os: windows-latest, python-version: "3.10" }
+          - { os: windows-latest, python-version: "3.14" }
+          - { os: macos-latest, python-version: "3.10" }
+          - { os: macos-latest, python-version: "3.14" }
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Which optimization

Backlog item **OC-7 — CI-matrix reduction**: trim redundant Python/OS combos in `.github/workflows/ci.yml` without losing meaningful coverage.

## Change

The `mcrit-install` job previously ran a full cross product of 3 operating systems × 5 Python versions = **15 jobs** per CI run. This replaces the cross product with a targeted `include` matrix of **9 jobs**:

- **ubuntu-latest** — all 5 supported Python versions (3.10–3.14)
- **windows-latest** — boundary versions only (3.10, 3.14)
- **macos-latest** — boundary versions only (3.10, 3.14)

No source, test, or lint changes.

## Rationale

The `mcrit-install` job verifies that the package installs and imports cleanly across platforms. The meaningful coverage dimensions it protects are:

1. **Every supported Python version installs/imports** — still fully covered on the primary ubuntu runner.
2. **Every OS works** — still fully covered; both boundary versions (oldest 3.10, newest 3.14) run on all three OSes, so each platform's native-wheel install path (capstone/lief) is still exercised.

The dropped combos are the *middle* minor versions (3.11–3.13) on the costlier **windows/macos** runners. These add little signal beyond the boundary checks: cross-OS install risk is driven by native wheels and platform behavior, which the min/max versions already cover, while per-Python-version risk is already covered on ubuntu. The dedicated `test` job (all 5 Pythons on ubuntu) is left untouched, so full Python-version test coverage is unchanged.

Net effect: ~40% fewer `mcrit-install` jobs, concentrated on the expensive macOS/Windows runners, with no loss of meaningful coverage.

## Verification

- `ruff check .` → All checks passed
- `ruff format --check .` → 96 files already formatted
- `pytest tests/test*` → 111 passed, 79 subtests passed
- YAML parsed and the resulting matrix asserted programmatically: 9 mcrit-install combos (ubuntu ×5, windows ×2, macos ×2); `test` job still runs all 5 Python versions.

## Correctness-preserving

This is a CI-configuration-only change. It does not touch disassembly/CFG output, instruction semantics, or any public behavior. It only reduces which redundant runner/interpreter combinations execute the existing install smoke check.

Draft for human review — not for merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LK74aVdyVJeftRugV2d9wj)_